### PR TITLE
Introduce key path syntax for response type computed fragment fields

### DIFF
--- a/Templates/Swift/ResponseType.stencil
+++ b/Templates/Swift/ResponseType.stencil
@@ -1,5 +1,9 @@
 {% extends "Base.stencil" %}
 {% block content %}
+{% if computedFragmentFields.count != 0 %}
+@dynamicMemberLookup
+
+{% endif %}
 {% if not asFile %}{{ accessLevel }} {% endif %}struct {{ name }}: GraphApiResponse, Equatable {
 	// MARK: - Response Fields
 	{% for field in fields %}
@@ -7,19 +11,20 @@
 		{{ accessLevel }} var {{ field|renderPropertyDeclaration }}
 	{% endfor %}
 
-	{% for field in computedFragmentFields %}
-		{% with field.attributes as attributes %}{% include "Helpers/Attributes.stencil" %}{% endwith %}
-		{{ accessLevel }} var {{ field|renderComputedPropertyDeclaration }} {
-			get {
-				return as{{ field.parentFragment.name }}Fragment{% if field.parentFragment.conditionallySelected %}?{% endif %}.{{ field.name }}
-			}
-			{% if not field.parentFragment.conditionallySelected %}
-			set {
-				as{{ field.parentFragment.name }}Fragment{% if field.parentFragment.conditionallySelected %}?{% endif %}.{{ field.name }} = newValue
-			}
-			{% endif %}
+	{% if computedFragmentFields.count != 0 %}
+	{% for fragment in fragmentSpreads %}
+		{% if fragment.conditionallySelected %}
+		{{ accessLevel }} subscript<T>(dynamicMember keyPath: KeyPath<{{ moduleName }}.{{ fragment.name }}?, T>) -> T? {
+			as{{ fragment.name }}Fragment?[keyPath: keyPath]
 		}
+		{% else %}
+		{{ accessLevel }} subscript<T>(dynamicMember keyPath: WritableKeyPath<{{moduleName }}.{{ fragment.name }}, T>) -> T {
+			get { as{{ fragment.name }}Fragment[keyPath: keyPath] }
+			set { as{{ fragment.name }}Fragment[keyPath: keyPath] = newValue }
+		}
+		{% endif %}
 	{% endfor %}
+	{% endif %}
 
 	{% for fragment in fragmentSpreads %}
 		{{ accessLevel }} var as{{ fragment.name }}Fragment: {{ moduleName }}.{{ fragment.name }}{% if fragment.conditionallySelected %}?{% endif %}

--- a/Tests/Resources/ExpectedSwiftCode/Fragments/InterfaceFragmentWithNestedFragmentNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Fragments/InterfaceFragmentWithNestedFragmentNext.swift
@@ -80,16 +80,12 @@ public struct BasePublishable: GraphApiResponse, Equatable {
 			self.__typename = "Publishable"
 	}
 		// MARK: - Nested Types
-			public struct ResourcePublications: GraphApiResponse, Equatable {
+			@dynamicMemberLookup
+	public struct ResourcePublications: GraphApiResponse, Equatable {
 		// MARK: - Response Fields
-			/// A list of edges.
-			public var edges: [MerchantApi.Publications.Edges] {
-				get {
-					return asPublicationsFragment.edges
-				}
-				set {
-					asPublicationsFragment.edges = newValue
-				}
+			public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.Publications, T>) -> T {
+				get { asPublicationsFragment[keyPath: keyPath] }
+				set { asPublicationsFragment[keyPath: keyPath] = newValue }
 			}
 			public var asPublicationsFragment: MerchantApi.Publications
 		// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Fragments/NestedFragmentSpreadNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Fragments/NestedFragmentSpreadNext.swift
@@ -2,19 +2,16 @@
 import Foundation
 
 public extension MerchantApi {
+@dynamicMemberLookup
+
 struct NestedFragmentSpread: GraphApiResponse, Equatable {
 	// MARK: - Response Fields
 		/// Globally unique identifier.
 		public var id: GraphID
 
-		/// The shop's features.
-		public var features: MerchantApi.Features.Features {
-			get {
-				return asFeaturesFragment.features
-			}
-			set {
-				asFeaturesFragment.features = newValue
-			}
+		public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.Features, T>) -> T {
+			get { asFeaturesFragment[keyPath: keyPath] }
+			set { asFeaturesFragment[keyPath: keyPath] = newValue }
 		}
 
 		public var asFeaturesFragment: MerchantApi.Features

--- a/Tests/Resources/ExpectedSwiftCode/Responses/BasicFragmentCustomerQueryResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/BasicFragmentCustomerQueryResponseNext.swift
@@ -61,25 +61,12 @@ struct BasicFragmentCustomerQueryResponse: GraphApiResponse, Equatable {
 						self.__typename = "CustomerEdge"
 				}
 					// MARK: - Nested Types
-						public struct Node: GraphApiResponse, Equatable {
+						@dynamicMemberLookup
+				public struct Node: GraphApiResponse, Equatable {
 					// MARK: - Response Fields
-						/// Globally unique identifier.
-						public var id: GraphID {
-							get {
-								return asBasicFragmentFragment.id
-							}
-							set {
-								asBasicFragmentFragment.id = newValue
-							}
-						}
-						/// A note about the customer.
-						public var note: String? {
-							get {
-								return asBasicFragmentFragment.note
-							}
-							set {
-								asBasicFragmentFragment.note = newValue
-							}
+						public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.BasicFragment, T>) -> T {
+							get { asBasicFragmentFragment[keyPath: keyPath] }
+							set { asBasicFragmentFragment[keyPath: keyPath] = newValue }
 						}
 						public var asBasicFragmentFragment: MerchantApi.BasicFragment
 					// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/ChannelDetailsResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/ChannelDetailsResponseNext.swift
@@ -58,88 +58,12 @@ public struct Node: GraphApiResponse, Equatable {
 		self.realized = realized
 		self.common = BaseNode()
 	}
+@dynamicMemberLookup
 public struct App: GraphApiResponse, Equatable {
 	// MARK: - Response Fields
-		/// Requirements that must be met before the app can be installed.
-		public var failedRequirements: [MerchantApi.ChannelDetailsFields.FailedRequirements] {
-			get {
-				return asChannelDetailsFieldsFragment.failedRequirements
-			}
-			set {
-				asChannelDetailsFieldsFragment.failedRequirements = newValue
-			}
-		}
-		/// Screenshots of the app.
-		public var screenshots: [MerchantApi.ChannelDetailsFields.Screenshots] {
-			get {
-				return asChannelDetailsFieldsFragment.screenshots
-			}
-			set {
-				asChannelDetailsFieldsFragment.screenshots = newValue
-			}
-		}
-		/// Icon that represents the app.
-		public var icon: MerchantApi.ChannelDetailsFields.Icon {
-			get {
-				return asChannelDetailsFieldsFragment.icon
-			}
-			set {
-				asChannelDetailsFieldsFragment.icon = newValue
-			}
-		}
-		/// Name of the app.
-		public var title: String {
-			get {
-				return asChannelDetailsFieldsFragment.title
-			}
-			set {
-				asChannelDetailsFieldsFragment.title = newValue
-			}
-		}
-		/// Detailed information about the app pricing.
-		public var pricingDetails: String? {
-			get {
-				return asChannelDetailsFieldsFragment.pricingDetails
-			}
-			set {
-				asChannelDetailsFieldsFragment.pricingDetails = newValue
-			}
-		}
-		/// Summary of the app pricing details.
-		public var pricingDetailsSummary: String {
-			get {
-				return asChannelDetailsFieldsFragment.pricingDetailsSummary
-			}
-			set {
-				asChannelDetailsFieldsFragment.pricingDetailsSummary = newValue
-			}
-		}
-		/// Description of the app.
-		public var description: String? {
-			get {
-				return asChannelDetailsFieldsFragment.description
-			}
-			set {
-				asChannelDetailsFieldsFragment.description = newValue
-			}
-		}
-		/// List of app features.
-		public var features: [String] {
-			get {
-				return asChannelDetailsFieldsFragment.features
-			}
-			set {
-				asChannelDetailsFieldsFragment.features = newValue
-			}
-		}
-		/// Webpage where you can install the app.
-		public var installUrl: URL? {
-			get {
-				return asChannelDetailsFieldsFragment.installUrl
-			}
-			set {
-				asChannelDetailsFieldsFragment.installUrl = newValue
-			}
+		public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.ChannelDetailsFields, T>) -> T {
+			get { asChannelDetailsFieldsFragment[keyPath: keyPath] }
+			set { asChannelDetailsFieldsFragment[keyPath: keyPath] = newValue }
 		}
 		public var asChannelDetailsFieldsFragment: MerchantApi.ChannelDetailsFields
 	// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/ConditionalDirectives2ResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/ConditionalDirectives2ResponseNext.swift
@@ -2,14 +2,13 @@
 import Foundation
 
 public extension MerchantApi {
+@dynamicMemberLookup
+
 struct ConditionalDirectives2Response: GraphApiResponse, Equatable {
 	// MARK: - Response Fields
 
-		/// Returns a Shop resource corresponding to access token used in request.
-		public var shop: MerchantApi.ConditionalDirectivesFrag2.Shop? {
-			get {
-				return asConditionalDirectivesFrag2Fragment?.shop
-			}
+		public subscript<T>(dynamicMember keyPath: KeyPath<MerchantApi.ConditionalDirectivesFrag2?, T>) -> T? {
+			asConditionalDirectivesFrag2Fragment?[keyPath: keyPath]
 		}
 
 		public var asConditionalDirectivesFrag2Fragment: MerchantApi.ConditionalDirectivesFrag2?

--- a/Tests/Resources/ExpectedSwiftCode/Responses/ConditionalDirectivesResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/ConditionalDirectivesResponseNext.swift
@@ -19,18 +19,14 @@ struct ConditionalDirectivesResponse: GraphApiResponse, Equatable {
 	}
 
 		// MARK: - Nested Types
-			public struct Shop: GraphApiResponse, Equatable {
+			@dynamicMemberLookup
+	public struct Shop: GraphApiResponse, Equatable {
 		// MARK: - Response Fields
 			/// The shop's primary domain name.
 			public var primaryDomain: PrimaryDomain?
-			/// The shop's features.
-			public var features: MerchantApi.ConditionalDirectivesFrag1.Features {
-				get {
-					return asConditionalDirectivesFrag1Fragment.features
-				}
-				set {
-					asConditionalDirectivesFrag1Fragment.features = newValue
-				}
+			public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.ConditionalDirectivesFrag1, T>) -> T {
+				get { asConditionalDirectivesFrag1Fragment[keyPath: keyPath] }
+				set { asConditionalDirectivesFrag1Fragment[keyPath: keyPath] = newValue }
 			}
 			public var asConditionalDirectivesFrag1Fragment: MerchantApi.ConditionalDirectivesFrag1
 		// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/CustomerEventsResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/CustomerEventsResponseNext.swift
@@ -32,16 +32,12 @@ struct CustomerEventsResponse: GraphApiResponse, Equatable {
 				self.__typename = "Customer"
 		}
 			// MARK: - Nested Types
-				public struct Events: GraphApiResponse, Equatable {
+				@dynamicMemberLookup
+		public struct Events: GraphApiResponse, Equatable {
 			// MARK: - Response Fields
-				/// A list of edges.
-				public var edges: [MerchantApi.MultiLevelInterfaceFragment.Edges] {
-					get {
-						return asMultiLevelInterfaceFragmentFragment.edges
-					}
-					set {
-						asMultiLevelInterfaceFragmentFragment.edges = newValue
-					}
+				public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.MultiLevelInterfaceFragment, T>) -> T {
+					get { asMultiLevelInterfaceFragmentFragment[keyPath: keyPath] }
+					set { asMultiLevelInterfaceFragmentFragment[keyPath: keyPath] = newValue }
 				}
 				public var asMultiLevelInterfaceFragmentFragment: MerchantApi.MultiLevelInterfaceFragment
 			// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/DeepMergeDuplicateFieldsResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/DeepMergeDuplicateFieldsResponseNext.swift
@@ -19,25 +19,12 @@ struct DeepMergeDuplicateFieldsResponse: GraphApiResponse, Equatable {
 	}
 
 		// MARK: - Nested Types
-			public struct Order: GraphApiResponse, Equatable {
+			@dynamicMemberLookup
+	public struct Order: GraphApiResponse, Equatable {
 		// MARK: - Response Fields
-			/// Globally unique identifier.
-			public var id: GraphID {
-				get {
-					return asDeepMergeDuplicateFieldsFragment.id
-				}
-				set {
-					asDeepMergeDuplicateFieldsFragment.id = newValue
-				}
-			}
-			/// List of shipments for the order.
-			public var fulfillments: [MerchantApi.DeepMergeDuplicateFields.Fulfillments] {
-				get {
-					return asDeepMergeDuplicateFieldsFragment.fulfillments
-				}
-				set {
-					asDeepMergeDuplicateFieldsFragment.fulfillments = newValue
-				}
+			public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.DeepMergeDuplicateFields, T>) -> T {
+				get { asDeepMergeDuplicateFieldsFragment[keyPath: keyPath] }
+				set { asDeepMergeDuplicateFieldsFragment[keyPath: keyPath] = newValue }
 			}
 			public var asDeepMergeDuplicateFieldsFragment: MerchantApi.DeepMergeDuplicateFields
 		// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/DuplicatedFragmentResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/DuplicatedFragmentResponseNext.swift
@@ -35,25 +35,12 @@ struct DuplicatedFragmentResponse: GraphApiResponse, Equatable {
 				self.__typename = "OrderUpdatePayload"
 		}
 			// MARK: - Nested Types
-				public struct UserErrors: GraphApiResponse, Equatable {
+				@dynamicMemberLookup
+		public struct UserErrors: GraphApiResponse, Equatable {
 			// MARK: - Response Fields
-				/// Path to the input field which caused the error.
-				public var field: [String]? {
-					get {
-						return asUserErrorsFragment.field
-					}
-					set {
-						asUserErrorsFragment.field = newValue
-					}
-				}
-				/// The error message.
-				public var message: String {
-					get {
-						return asUserErrorsFragment.message
-					}
-					set {
-						asUserErrorsFragment.message = newValue
-					}
+				public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.UserErrors, T>) -> T {
+					get { asUserErrorsFragment[keyPath: keyPath] }
+					set { asUserErrorsFragment[keyPath: keyPath] = newValue }
 				}
 				public var asUserErrorsFragment: MerchantApi.UserErrors
 			// MARK: - Helpers
@@ -96,25 +83,12 @@ struct DuplicatedFragmentResponse: GraphApiResponse, Equatable {
 				self.__typename = "CustomerUpdatePayload"
 		}
 			// MARK: - Nested Types
-				public struct UserErrors: GraphApiResponse, Equatable {
+				@dynamicMemberLookup
+		public struct UserErrors: GraphApiResponse, Equatable {
 			// MARK: - Response Fields
-				/// Path to the input field which caused the error.
-				public var field: [String]? {
-					get {
-						return asUserErrorsFragment.field
-					}
-					set {
-						asUserErrorsFragment.field = newValue
-					}
-				}
-				/// The error message.
-				public var message: String {
-					get {
-						return asUserErrorsFragment.message
-					}
-					set {
-						asUserErrorsFragment.message = newValue
-					}
+				public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.UserErrors, T>) -> T {
+					get { asUserErrorsFragment[keyPath: keyPath] }
+					set { asUserErrorsFragment[keyPath: keyPath] = newValue }
 				}
 				public var asUserErrorsFragment: MerchantApi.UserErrors
 			// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/InterfaceFragmentWithNestedFragmentResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/InterfaceFragmentWithNestedFragmentResponseNext.swift
@@ -116,25 +116,12 @@ struct InterfaceFragmentWithNestedFragmentResponse: GraphApiResponse, Equatable 
 						self.realized = realized
 						self.common = BasePublishable(interfaceFragmentWithNestedFragmentFragment: interfaceFragmentWithNestedFragmentFragment)
 					}
+				@dynamicMemberLookup
 				public struct BasePublishable: GraphApiResponse, Equatable {
 					// MARK: - Response Fields
-						/// The number of publications a resource is published to without feedback errors.
-						public var availablePublicationCount: Int32 {
-							get {
-								return asInterfaceFragmentWithNestedFragmentFragment.availablePublicationCount
-							}
-							set {
-								asInterfaceFragmentWithNestedFragmentFragment.availablePublicationCount = newValue
-							}
-						}
-						/// The list of resources that are published to a publication.
-						public var resourcePublications: MerchantApi.InterfaceFragmentWithNestedFragment.ResourcePublications {
-							get {
-								return asInterfaceFragmentWithNestedFragmentFragment.resourcePublications
-							}
-							set {
-								asInterfaceFragmentWithNestedFragmentFragment.resourcePublications = newValue
-							}
+						public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.InterfaceFragmentWithNestedFragment, T>) -> T {
+							get { asInterfaceFragmentWithNestedFragmentFragment[keyPath: keyPath] }
+							set { asInterfaceFragmentWithNestedFragmentFragment[keyPath: keyPath] = newValue }
 						}
 						public var asInterfaceFragmentWithNestedFragmentFragment: MerchantApi.InterfaceFragmentWithNestedFragment
 					// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/InterfaceWrapperNestedFragmentResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/InterfaceWrapperNestedFragmentResponseNext.swift
@@ -141,16 +141,12 @@ struct InterfaceWrapperNestedFragmentResponse: GraphApiResponse, Equatable {
 							self.__typename = "Publishable"
 					}
 						// MARK: - Nested Types
-							public struct ResourcePublications: GraphApiResponse, Equatable {
+							@dynamicMemberLookup
+					public struct ResourcePublications: GraphApiResponse, Equatable {
 						// MARK: - Response Fields
-							/// A list of edges.
-							public var edges: [MerchantApi.Publications.Edges] {
-								get {
-									return asPublicationsFragment.edges
-								}
-								set {
-									asPublicationsFragment.edges = newValue
-								}
+							public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.Publications, T>) -> T {
+								get { asPublicationsFragment[keyPath: keyPath] }
+								set { asPublicationsFragment[keyPath: keyPath] = newValue }
 							}
 							public var asPublicationsFragment: MerchantApi.Publications
 						// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/MultiLevelFragmentCustomerQueryResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/MultiLevelFragmentCustomerQueryResponseNext.swift
@@ -61,16 +61,12 @@ struct MultiLevelFragmentCustomerQueryResponse: GraphApiResponse, Equatable {
 						self.__typename = "CustomerEdge"
 				}
 					// MARK: - Nested Types
-						public struct Node: GraphApiResponse, Equatable {
+						@dynamicMemberLookup
+				public struct Node: GraphApiResponse, Equatable {
 					// MARK: - Response Fields
-						/// The customer's last order.
-						public var lastOrder: MerchantApi.MultiLevelFragment.LastOrder? {
-							get {
-								return asMultiLevelFragmentFragment.lastOrder
-							}
-							set {
-								asMultiLevelFragmentFragment.lastOrder = newValue
-							}
+						public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.MultiLevelFragment, T>) -> T {
+							get { asMultiLevelFragmentFragment[keyPath: keyPath] }
+							set { asMultiLevelFragmentFragment[keyPath: keyPath] = newValue }
 						}
 						public var asMultiLevelFragmentFragment: MerchantApi.MultiLevelFragment
 					// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/MultiLevelInterfaceFragmentWithOnlyInlineFragmentsQueryResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/MultiLevelInterfaceFragmentWithOnlyInlineFragmentsQueryResponseNext.swift
@@ -32,16 +32,12 @@ struct MultiLevelInterfaceFragmentWithOnlyInlineFragmentsQueryResponse: GraphApi
 				self.__typename = "Customer"
 		}
 			// MARK: - Nested Types
-				public struct Events: GraphApiResponse, Equatable {
+				@dynamicMemberLookup
+		public struct Events: GraphApiResponse, Equatable {
 			// MARK: - Response Fields
-				/// A list of edges.
-				public var edges: [MerchantApi.MultiLevelInterfaceFragmentWithOnlyInlineFragments.Edges] {
-					get {
-						return asMultiLevelInterfaceFragmentWithOnlyInlineFragmentsFragment.edges
-					}
-					set {
-						asMultiLevelInterfaceFragmentWithOnlyInlineFragmentsFragment.edges = newValue
-					}
+				public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.MultiLevelInterfaceFragmentWithOnlyInlineFragments, T>) -> T {
+					get { asMultiLevelInterfaceFragmentWithOnlyInlineFragmentsFragment[keyPath: keyPath] }
+					set { asMultiLevelInterfaceFragmentWithOnlyInlineFragmentsFragment[keyPath: keyPath] = newValue }
 				}
 				public var asMultiLevelInterfaceFragmentWithOnlyInlineFragmentsFragment: MerchantApi.MultiLevelInterfaceFragmentWithOnlyInlineFragments
 			// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/MultipleDuplicatedFragmentsResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/MultipleDuplicatedFragmentsResponseNext.swift
@@ -19,16 +19,12 @@ struct MultipleDuplicatedFragmentsResponse: GraphApiResponse, Equatable {
 	}
 
 		// MARK: - Nested Types
-			public struct Shop: GraphApiResponse, Equatable {
+			@dynamicMemberLookup
+	public struct Shop: GraphApiResponse, Equatable {
 		// MARK: - Response Fields
-			/// The shop's name.
-			public var name: String {
-				get {
-					return asDuplicatedFragmentFragment.name
-				}
-				set {
-					asDuplicatedFragmentFragment.name = newValue
-				}
+			public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.DuplicatedFragment, T>) -> T {
+				get { asDuplicatedFragmentFragment[keyPath: keyPath] }
+				set { asDuplicatedFragmentFragment[keyPath: keyPath] = newValue }
 			}
 			public var asDuplicatedFragmentFragment: MerchantApi.DuplicatedFragment
 		// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/MultipleFragmentsQueryResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/MultipleFragmentsQueryResponseNext.swift
@@ -61,34 +61,16 @@ struct MultipleFragmentsQueryResponse: GraphApiResponse, Equatable {
 						self.__typename = "CustomerEdge"
 				}
 					// MARK: - Nested Types
-						public struct Node: GraphApiResponse, Equatable {
+						@dynamicMemberLookup
+				public struct Node: GraphApiResponse, Equatable {
 					// MARK: - Response Fields
-						/// Globally unique identifier.
-						public var id: GraphID {
-							get {
-								return asBasicFragmentFragment.id
-							}
-							set {
-								asBasicFragmentFragment.id = newValue
-							}
+						public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.BasicFragment, T>) -> T {
+							get { asBasicFragmentFragment[keyPath: keyPath] }
+							set { asBasicFragmentFragment[keyPath: keyPath] = newValue }
 						}
-						/// A note about the customer.
-						public var note: String? {
-							get {
-								return asBasicFragmentFragment.note
-							}
-							set {
-								asBasicFragmentFragment.note = newValue
-							}
-						}
-						/// The customer's last order.
-						public var lastOrder: MerchantApi.MultiLevelFragment.LastOrder? {
-							get {
-								return asMultiLevelFragmentFragment.lastOrder
-							}
-							set {
-								asMultiLevelFragmentFragment.lastOrder = newValue
-							}
+						public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.MultiLevelFragment, T>) -> T {
+							get { asMultiLevelFragmentFragment[keyPath: keyPath] }
+							set { asMultiLevelFragmentFragment[keyPath: keyPath] = newValue }
 						}
 						public var asBasicFragmentFragment: MerchantApi.BasicFragment
 						public var asMultiLevelFragmentFragment: MerchantApi.MultiLevelFragment

--- a/Tests/Resources/ExpectedSwiftCode/Responses/NestedFragmentResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/NestedFragmentResponseNext.swift
@@ -19,16 +19,12 @@ struct NestedFragmentResponse: GraphApiResponse, Equatable {
 	}
 
 		// MARK: - Nested Types
-			public struct Shop: GraphApiResponse, Equatable {
+			@dynamicMemberLookup
+	public struct Shop: GraphApiResponse, Equatable {
 		// MARK: - Response Fields
-			/// Globally unique identifier.
-			public var id: GraphID {
-				get {
-					return asNestedFragmentSpreadFragment.id
-				}
-				set {
-					asNestedFragmentSpreadFragment.id = newValue
-				}
+			public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.NestedFragmentSpread, T>) -> T {
+				get { asNestedFragmentSpreadFragment[keyPath: keyPath] }
+				set { asNestedFragmentSpreadFragment[keyPath: keyPath] = newValue }
 			}
 			public var asNestedFragmentSpreadFragment: MerchantApi.NestedFragmentSpread
 		// MARK: - Helpers

--- a/Tests/Resources/ExpectedSwiftCode/Responses/TopLevelFragmentQueryResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/TopLevelFragmentQueryResponseNext.swift
@@ -2,17 +2,14 @@
 import Foundation
 
 public extension MerchantApi {
+@dynamicMemberLookup
+
 struct TopLevelFragmentQueryResponse: GraphApiResponse, Equatable {
 	// MARK: - Response Fields
 
-		/// Returns a specific node by ID.
-		public var node: MerchantApi.TopLevelFragment.Node? {
-			get {
-				return asTopLevelFragmentFragment.node
-			}
-			set {
-				asTopLevelFragmentFragment.node = newValue
-			}
+		public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.TopLevelFragment, T>) -> T {
+			get { asTopLevelFragmentFragment[keyPath: keyPath] }
+			set { asTopLevelFragmentFragment[keyPath: keyPath] = newValue }
 		}
 
 		public var asTopLevelFragmentFragment: MerchantApi.TopLevelFragment

--- a/Tests/Resources/ExpectedSwiftCode/Responses/Union3ResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/Union3ResponseNext.swift
@@ -2,17 +2,14 @@
 import Foundation
 
 public extension MerchantApi {
+@dynamicMemberLookup
+
 struct Union3Response: GraphApiResponse, Equatable {
 	// MARK: - Response Fields
 
-		/// Lookup a price rule by ID.
-		public var priceRule: MerchantApi.UnionFrag2.PriceRule? {
-			get {
-				return asUnionFrag2Fragment.priceRule
-			}
-			set {
-				asUnionFrag2Fragment.priceRule = newValue
-			}
+		public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.UnionFrag2, T>) -> T {
+			get { asUnionFrag2Fragment[keyPath: keyPath] }
+			set { asUnionFrag2Fragment[keyPath: keyPath] = newValue }
 		}
 
 		public var asUnionFrag2Fragment: MerchantApi.UnionFrag2

--- a/Tests/Resources/ExpectedSwiftCode/Responses/Union4ResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/Union4ResponseNext.swift
@@ -19,19 +19,12 @@ struct Union4Response: GraphApiResponse, Equatable {
 	}
 
 		// MARK: - Nested Types
-			public struct PriceRule: GraphApiResponse, Equatable {
+			@dynamicMemberLookup
+	public struct PriceRule: GraphApiResponse, Equatable {
 		// MARK: - Response Fields
-			/// The value of the price rule.
-			/// - Warning:
-			/// Use `valueV2` instead
-	@available(*, deprecated, message: "")
-			public var value: MerchantApi.UnionFrag4.Value {
-				get {
-					return asUnionFrag4Fragment.value
-				}
-				set {
-					asUnionFrag4Fragment.value = newValue
-				}
+			public subscript<T>(dynamicMember keyPath: WritableKeyPath<MerchantApi.UnionFrag4, T>) -> T {
+				get { asUnionFrag4Fragment[keyPath: keyPath] }
+				set { asUnionFrag4Fragment[keyPath: keyPath] = newValue }
 			}
 			public var asUnionFrag4Fragment: MerchantApi.UnionFrag4
 		// MARK: - Helpers


### PR DESCRIPTION
In [SE-252](https://github.com/apple/swift-evolution/blob/master/proposals/0252-keypath-dynamic-member-lookup.md), Swift introduced syntax that allows passing property-like calls to a property.  This change introduces that functionality.

## Description of change

In Swift pre 5.1, it was common to write code similar to the following block

```swift
struct Point {
    let x: Int
    let y: Int
}

struct Circle {
    let center: Point
    let radius: Double

    var x: Int {
        return center.x
    }

    var x: Int {
        return center.y
    }
}
```
After and including Swift 5.1, this block can be shortened to
```swift
struct Point {
    let x: Int
    let y: Int
}

@dynamicMemberLookup
struct Circle {
    let center: Point
    let radius: Int

    subscript<U>(dynamicMember keyPath: KeyPath<Point, U>) -> U {
        center[keyPath: keyPath]
    }
}
```
Both call sites would look like
```swift
let center = Point(x: 1, y: 2)
let circle = Circle(center: center, radius: 1)
circle.x
circle.y
```
With the second option, there is no need to add properties if the underlying model changes.

This change incorporates this idea with the computed fragment fields.
