### PR TITLE
Introduce conformance to Identifiable protocol

### DIFF
--- a/Templates/Swift/GraphApi.stencil
+++ b/Templates/Swift/GraphApi.stencil
@@ -434,3 +434,23 @@ private extension GraphApiResponse {
 		}
 	}
 }
+
+#if compiler(<5.1)
+/// A class of types whose instances hold the value of an entity with stable identity.
+/// See https://github.com/apple/swift/blob/master/stdlib/public/core/Identifiable.swift
+/// for more details.
+public protocol Identifiable {
+
+	/// A type representing the stable identity of the entity associated with `self`.
+	associatedtype ID: Hashable
+
+	/// The stable identity of the entity associated with `self`.
+	var id: ID { get }
+}
+
+extension Identifiable where Self: AnyObject {
+	public var id: ObjectIdentifier {
+		return ObjectIdentifier(self)
+	}
+}
+#endif

--- a/Templates/Swift/InterfaceWrapper.stencil
+++ b/Templates/Swift/InterfaceWrapper.stencil
@@ -1,6 +1,6 @@
 {% extends "Base.stencil" %}
 {% block content %}
-{% if not asFile %}{{ accessLevel }} {% endif %}struct {{ name }}: GraphApiResponse, Equatable {
+{% if not asFile %}{{ accessLevel }} {% endif %}struct {{ name }}: GraphApiResponse, {% if "id" in computedFragmentFields %}Identifiable, {% endif %}Equatable {
 	{{ accessLevel }} var realized: Realized
 	private var common: {{ fallbackTypeName }}
 	{{ accessLevel }} var __typename: String

--- a/Templates/Swift/ResponseType.stencil
+++ b/Templates/Swift/ResponseType.stencil
@@ -1,6 +1,6 @@
 {% extends "Base.stencil" %}
 {% block content %}
-{% if not asFile %}{{ accessLevel }} {% endif %}struct {{ name }}: GraphApiResponse, Equatable {
+{% if not asFile %}{{ accessLevel }} {% endif %}struct {{ name }}: GraphApiResponse, {% if "id" in computedFragmentFields or "id" in fields %}Identifiable, {% endif %}Equatable {
 	// MARK: - Response Fields
 	{% for field in fields %}
 		{% with field.attributes as attributes %}{% include "Helpers/Attributes.stencil" %}{% endwith %}

--- a/Tests/Resources/ExpectedSwiftCode/GraphApi.swift
+++ b/Tests/Resources/ExpectedSwiftCode/GraphApi.swift
@@ -435,3 +435,23 @@ private extension GraphApiResponse {
 		}
 	}
 }
+
+#if compiler(<5.1)
+/// A class of types whose instances hold the value of an entity with stable identity.
+/// See https://github.com/apple/swift/blob/master/stdlib/public/core/Identifiable.swift
+/// for more details.
+public protocol Identifiable {
+
+	/// A type representing the stable identity of the entity associated with `self`.
+	associatedtype ID: Hashable
+
+	/// The stable identity of the entity associated with `self`.
+	var id: ID { get }
+}
+
+extension Identifiable where Self: AnyObject {
+	public var id: ObjectIdentifier {
+		return ObjectIdentifier(self)
+	}
+}
+#endif


### PR DESCRIPTION
Swift 5.1 introduced the `Identifiable` protocol (See this [file](https://github.com/apple/swift/blob/master/stdlib/public/core/Identifiable.swift) and this [evolution](https://github.com/apple/swift-evolution/blob/master/proposals/0261-identifiable.md))

## Description

This change
* adds `Identifiable` conformance response types and interface types
* adds `Identifiable` protocol to `GraphApi` if the compiler version is less than 5.1.