### PR TITLE
Support custom scalars in Swift operations

### DIFF
--- a/Sources/SyrupCore/Generator/Renderer.swift
+++ b/Sources/SyrupCore/Generator/Renderer.swift
@@ -82,6 +82,7 @@ open class Renderer {
 		let importEnums = intermediateRepresentation.referencedEnums.isEmpty == false
 		let importInputs = intermediateRepresentation.referencedInputTypes.isEmpty == false
 		let importFragments = intermediateRepresentation.fragmentDefinitions.isEmpty == false
+		let requiresCustomEncoder = query.variables.contains(where: { $0.type.nestedScalar() is IntermediateRepresentation.CustomCodedScalar})
 		let context: [String: Any] = [
 			"name": name,
 			"operation": query,
@@ -91,6 +92,7 @@ open class Renderer {
 			"importEnums": importEnums,
 			"importInputs": importInputs,
 			"importFragments": importFragments,
+			"requiresCustomEncoder": requiresCustomEncoder,
 			"selections": querySelections.selectionSet
 		]
 		return try render(template: "Operation", asFile: true, context: context)
@@ -110,6 +112,7 @@ open class Renderer {
 		let importEnums = intermediateRepresentation.referencedEnums.isEmpty == false
 		let importInputs = intermediateRepresentation.referencedInputTypes.isEmpty == false
 		let importFragments = intermediateRepresentation.fragmentDefinitions.isEmpty == false
+		let requiresCustomEncoder = mutation.variables.contains(where: { $0.type.nestedScalar() is IntermediateRepresentation.CustomCodedScalar})
 		let context: [String: Any] = [
 			"name": name,
 			"operation": mutation,
@@ -119,6 +122,7 @@ open class Renderer {
 			"importEnums": importEnums,
 			"importInputs": importInputs,
 			"importFragments": importFragments,
+			"requiresCustomEncoder": requiresCustomEncoder,
 			"selections": mutationSelections.selectionSet
 		]
 		return try render(template: "Operation", asFile: true, context: context)

--- a/Templates/Swift/Operation.stencil
+++ b/Templates/Swift/Operation.stencil
@@ -23,11 +23,19 @@
 				case {{ variable.name|escapeReservedWord }}
 			{% endfor %}
 		}
+
 		{% if requiresCustomEncoder %}
 			{{ accessLevel }} func encode(to encoder: Encoder) throws {
+				let customScalarResolver = {{ moduleName }}.customScalarResolver
 				var container = encoder.container(keyedBy: CodingKeys.self)
 				{% for variable in operation.variables %}
-					{% with variable as field %}{% include "Helpers/EncodeField.stencil" %}{% endwith %}
+					{% if variable|requiresCustomCoder %}
+						try customScalarResolver.encode({{ variable.name|escapeReservedWord }}, rawValueType: {{ variable|nestedRawValueType }}.self, forKey: .{{ variable.name|escapeReservedWord }}, container: &container) { [codingPath = container.codingPath] (value) -> {{ variable|nestedRawValueType }} in
+							return try customScalarResolver.encoderFor{{ variable|nestedGraphType }}(value, codingPath)
+						}
+					{% else %}
+						try container.encode({{ variable.name|escapeReservedWord }}, forKey: .{{ variable.name|escapeReservedWord }})
+					{% endif %}
 				{% endfor %}
 			}
 		{% endif %}


### PR DESCRIPTION
Resolves issue https://github.com/Shopify/syrup/issues/5. Allows you to generate queries and mutations which have custom scalar types as parameters.

For the mutation referenced in https://github.com/Shopify/syrup/issues/5, this ends up generating an encode function like so,

```swift
		public func encode(to encoder: Encoder) throws {
			let customScalarResolver = ShopifyMerchantApi.customScalarResolver
			var container = encoder.container(keyedBy: CodingKeys.self)
			try customScalarResolver.encode(initialValue, rawValueType: String.self, forKey: .initialValue, container: &container) { [codingPath = container.codingPath] (value) -> String in
				return try customScalarResolver.encoderForDecimal(value, codingPath)
			}
			try container.encode(code, forKey: .code)
			try container.encode(customerId, forKey: .customerId)
			try customScalarResolver.encode(expiresOn, rawValueType: String?.self, forKey: .expiresOn, container: &container) { [codingPath = container.codingPath] (value) -> String? in
				return try customScalarResolver.encoderForDate(value, codingPath)
			}
			try container.encode(note, forKey: .note)
			try container.encode(templateSuffix, forKey: .templateSuffix)
		}
```

I don't know of any operations in the public schema that have custom scalars as parameters so I can't update the tests. I could modify the schema to have a fake one - is that something we'd want to do? 


To 🎩 locally, you update your `Mintfile` to point to the syrup `operations-custom-scalars` branch.