### PR TITLE
Add missing GraphQL query in Swift sample

### DIFF
--- a/samples/swift/.syrup.yml
+++ b/samples/swift/.syrup.yml
@@ -1,4 +1,4 @@
-location: ""
+location: schema.json
 customScalars: []
 moduleName: StarWarsAPI
 header: |

--- a/samples/swift/GraphQL/Films.graphql
+++ b/samples/swift/GraphQL/Films.graphql
@@ -1,0 +1,12 @@
+query Films($first: Int!) {
+  allFilms(first: $first) {
+    edges {
+      node {
+        id
+        title
+        director
+        openingCrawl
+      }
+    }
+  }
+}

--- a/samples/swift/Sample.playground/Sources/Generated/Responses/FilmsResponse.swift
+++ b/samples/swift/Sample.playground/Sources/Generated/Responses/FilmsResponse.swift
@@ -14,7 +14,7 @@ struct FilmsResponse: GraphApiResponse, Equatable {
 
 	public init(allFilms: AllFilms?) {
 			self.allFilms = allFilms
-			self.__typename = "QueryRoot"
+			self.__typename = "Root"
 	}
 
 		// MARK: - Nested Types

--- a/samples/swift/generate
+++ b/samples/swift/generate
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-mint run shopify/syrup@master syrup generate GraphQL Sample.playground/Sources/Generated Sample.playground/Sources/Generated "Swift" --override-schema "schema.json"
+mint run shopify/syrup@master syrup generate GraphQL Sample.playground/Sources/Generated Sample.playground/Sources/Generated "Swift"


### PR DESCRIPTION
Noticed the queries weren't committed for the Swift sample.

Running `generate` script in Swift sample should generate GraphQL models successfully.