### PR TITLE
Remove unused companion objects on Response type

### DIFF
--- a/Templates/Kotlin/ResponseType.stencil
+++ b/Templates/Kotlin/ResponseType.stencil
@@ -29,15 +29,13 @@ data class {{ name }}(
         {% endfor %}
     )
 
+    {% if fragmentSelections %}
     companion object {
-        const val typeName = "{{ graphQLName }}"
-
-        {% if fragmentSelections %}
         fun getSelections(operationVariables: Map<String, String>): List<Selection> {
             return {{ fragmentSelections|renderKotlinSelections:graphQLName }}
         }
-        {% endif %}
     }
+    {% endif %}
 
     {% for field in fields %}
     {{ field|nestedTypeDefinition }}

--- a/Tests/Resources/ExpectedKotlinCode/Fragments/BasicFragment.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Fragments/BasicFragment.kt
@@ -27,8 +27,6 @@ data class BasicFragment(
     )
 
     companion object {
-        const val typeName = "Customer"
-
         fun getSelections(operationVariables: Map<String, String>): List<Selection> {
             return listOf<Selection>(
 Selection(

--- a/Tests/Resources/ExpectedKotlinCode/Fragments/FragmentWithConditional.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Fragments/FragmentWithConditional.kt
@@ -21,8 +21,6 @@ data class FragmentWithConditional(
     )
 
     companion object {
-        const val typeName = "Shop"
-
         fun getSelections(operationVariables: Map<String, String>): List<Selection> {
             return listOf<Selection>(
 Selection(

--- a/Tests/Resources/ExpectedKotlinCode/Fragments/ProductNodeTitle.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Fragments/ProductNodeTitle.kt
@@ -21,8 +21,6 @@ data class ProductNodeTitle(
     )
 
     companion object {
-        const val typeName = "Product"
-
         fun getSelections(operationVariables: Map<String, String>): List<Selection> {
             return listOf<Selection>(
 Selection(

--- a/Tests/Resources/ExpectedKotlinCode/Fragments/Shop.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Fragments/Shop.kt
@@ -21,8 +21,6 @@ data class Shop(
     )
 
     companion object {
-        const val typeName = "QueryRoot"
-
         fun getSelections(operationVariables: Map<String, String>): List<Selection> {
             return listOf<Selection>(
 Selection(
@@ -77,9 +75,6 @@ selections = listOf<Selection>()))))))))))
         constructor(jsonObject: JsonObject) : this(
             availableChannelApps = AvailableChannelApps(jsonObject.getAsJsonObject("availableChannelApps"))
         )
-        companion object {
-            const val typeName = "Shop"
-        }
             data class AvailableChannelApps(
             /**
              * A list of edges.
@@ -96,9 +91,6 @@ selections = listOf<Selection>()))))))))))
         list
         }
             )
-            companion object {
-                const val typeName = "AppConnection"
-            }
                 data class Edges(
                 /**
                  * The item at the end of AppEdge.
@@ -108,9 +100,6 @@ selections = listOf<Selection>()))))))))))
                 constructor(jsonObject: JsonObject) : this(
                     node = Node(jsonObject.getAsJsonObject("node"))
                 )
-                companion object {
-                    const val typeName = "AppEdge"
-                }
                     data class Node(
                     /**
                      * Globally unique identifier.
@@ -120,9 +109,6 @@ selections = listOf<Selection>()))))))))))
                     constructor(jsonObject: JsonObject) : this(
                         id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java)
                     )
-                    companion object {
-                        const val typeName = "App"
-                    }
                 }
             }
         }

--- a/Tests/Resources/ExpectedKotlinCode/Fragments/TimelineEventFragment.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Fragments/TimelineEventFragment.kt
@@ -234,9 +234,6 @@ this.forEach {
 list
 }
     )
-    companion object {
-        const val typeName = "CommentEvent"
-    }
         data class Attachments(
         /**
          * Globally unique identifier.
@@ -271,9 +268,6 @@ list
             url = OperationGsonBuilder.gson.fromJson(jsonObject.get("url"), String::class.java),
             image = if (jsonObject.has("image") && !jsonObject.get("image").isJsonNull) Image(jsonObject.getAsJsonObject("image")) else null
         )
-        companion object {
-            const val typeName = "CommentEventAttachment"
-        }
             data class Image(
             /**
              * The location of the transformed image as a URL.
@@ -285,9 +279,6 @@ list
             constructor(jsonObject: JsonObject) : this(
                 transformedSrc = OperationGsonBuilder.gson.fromJson(jsonObject.get("transformedSrc"), String::class.java)
             )
-            companion object {
-                const val typeName = "Image"
-            }
         }
     }
 }

--- a/Tests/Resources/ExpectedKotlinCode/Fragments/TimelineFragment.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Fragments/TimelineFragment.kt
@@ -34,8 +34,6 @@ list
     )
 
     companion object {
-        const val typeName = "EventConnection"
-
         fun getSelections(operationVariables: Map<String, String>): List<Selection> {
             return listOf<Selection>(
 Selection(
@@ -226,9 +224,6 @@ selections = listOf<Selection>()))))))))))
         constructor(jsonObject: JsonObject) : this(
             hasNextPage = OperationGsonBuilder.gson.fromJson(jsonObject.get("hasNextPage"), Boolean::class.java)
         )
-        companion object {
-            const val typeName = "PageInfo"
-        }
     }
         data class Edges(
         /**
@@ -244,9 +239,6 @@ selections = listOf<Selection>()))))))))))
             cursor = OperationGsonBuilder.gson.fromJson(jsonObject.get("cursor"), String::class.java),
             node = Node(jsonObject.getAsJsonObject("node"))
         )
-        companion object {
-            const val typeName = "EventEdge"
-        }
     data class Node(
         val realized: Realized,
         val id: ID ,
@@ -333,9 +325,6 @@ selections = listOf<Selection>()))))))))))
     list
     }
         )
-        companion object {
-            const val typeName = "CommentEvent"
-        }
             data class Attachments(
             /**
              * Globally unique identifier.
@@ -370,9 +359,6 @@ selections = listOf<Selection>()))))))))))
                 url = OperationGsonBuilder.gson.fromJson(jsonObject.get("url"), String::class.java),
                 image = if (jsonObject.has("image") && !jsonObject.get("image").isJsonNull) Image(jsonObject.getAsJsonObject("image")) else null
             )
-            companion object {
-                const val typeName = "CommentEventAttachment"
-            }
                 data class Image(
                 /**
                  * The location of the transformed image as a URL.
@@ -384,9 +370,6 @@ selections = listOf<Selection>()))))))))))
                 constructor(jsonObject: JsonObject) : this(
                     transformedSrc = OperationGsonBuilder.gson.fromJson(jsonObject.get("transformedSrc"), String::class.java)
                 )
-                companion object {
-                    const val typeName = "Image"
-                }
             }
         }
     }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/CreateCollectionResponse.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/CreateCollectionResponse.kt
@@ -20,11 +20,6 @@ data class CreateCollectionResponse(
         collectionCreate = if (jsonObject.has("collectionCreate") && !jsonObject.get("collectionCreate").isJsonNull) CollectionCreate(jsonObject.getAsJsonObject("collectionCreate")) else null
     )
 
-    companion object {
-        const val typeName = "Mutation"
-
-    }
-
         data class CollectionCreate(
         /**
          * List of errors that occurred executing the mutation.
@@ -46,9 +41,6 @@ data class CreateCollectionResponse(
     },
             collection = if (jsonObject.has("collection") && !jsonObject.get("collection").isJsonNull) Collection(jsonObject.getAsJsonObject("collection")) else null
         )
-        companion object {
-            const val typeName = "CollectionCreatePayload"
-        }
             data class UserErrors(
             /**
              * Path to the input field which caused the error.
@@ -67,9 +59,6 @@ data class CreateCollectionResponse(
         },
                 message = OperationGsonBuilder.gson.fromJson(jsonObject.get("message"), String::class.java)
             )
-            companion object {
-                const val typeName = "UserError"
-            }
         }
             data class Collection(
             /**
@@ -90,9 +79,6 @@ data class CreateCollectionResponse(
                 id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java),
                 feedback = if (jsonObject.has("feedback") && !jsonObject.get("feedback").isJsonNull) Feedback(jsonObject.getAsJsonObject("feedback")) else null
             )
-            companion object {
-                const val typeName = "Collection"
-            }
                 data class Feedback(
                 /**
                  * Summary of resource feedback pertaining to the resource.
@@ -102,9 +88,6 @@ data class CreateCollectionResponse(
                 constructor(jsonObject: JsonObject) : this(
                     summary = OperationGsonBuilder.gson.fromJson(jsonObject.get("summary"), String::class.java)
                 )
-                companion object {
-                    const val typeName = "ResourceFeedback"
-                }
             }
         }
     }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/MarketingOptInLevelResponse.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/MarketingOptInLevelResponse.kt
@@ -20,11 +20,6 @@ data class MarketingOptInLevelResponse(
         customers = Customers(jsonObject.getAsJsonObject("customers"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Customers(
         /**
          * A list of edges.
@@ -41,9 +36,6 @@ data class MarketingOptInLevelResponse(
     list
     }
         )
-        companion object {
-            const val typeName = "CustomerConnection"
-        }
             data class Edges(
             /**
              * The item at the end of CustomerEdge.
@@ -53,9 +45,6 @@ data class MarketingOptInLevelResponse(
             constructor(jsonObject: JsonObject) : this(
                 node = Node(jsonObject.getAsJsonObject("node"))
             )
-            companion object {
-                const val typeName = "CustomerEdge"
-            }
                 data class Node(
                 /**
                  * The marketing subscription opt-in level (as described by the M3AAWG best practices guideline) that the
@@ -67,9 +56,6 @@ data class MarketingOptInLevelResponse(
                 constructor(jsonObject: JsonObject) : this(
                     marketingOptInLevel = if (jsonObject.has("marketingOptInLevel") && !jsonObject.get("marketingOptInLevel").isJsonNull) CustomerMarketingOptInLevel.safeValueOf(jsonObject.decodeEnumValue<CustomerMarketingOptInLevel>("marketingOptInLevel")) else null
                 )
-                companion object {
-                    const val typeName = "Customer"
-                }
             }
         }
     }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/NodeInterfacesResponse.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/NodeInterfacesResponse.kt
@@ -21,11 +21,6 @@ data class NodeInterfacesResponse(
         node = if (jsonObject.has("node") && !jsonObject.get("node").isJsonNull) Node(jsonObject.getAsJsonObject("node")) else null
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
 data class Node(
     val realized: Realized,
     val nodeId: NodeId 
@@ -49,9 +44,6 @@ data class Product(
         nodeId = com.shopify.syrup.fragments.NodeId(jsonObject),
         productNodeTitle = com.shopify.syrup.fragments.ProductNodeTitle(jsonObject)
     )
-    companion object {
-        const val typeName = "Product"
-    }
 }
     object Other: Realized()
 }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/ProductVariantShippingResponse.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/ProductVariantShippingResponse.kt
@@ -20,11 +20,6 @@ data class ProductVariantShippingResponse(
         productVariantUpdate = if (jsonObject.has("productVariantUpdate") && !jsonObject.get("productVariantUpdate").isJsonNull) ProductVariantUpdate(jsonObject.getAsJsonObject("productVariantUpdate")) else null
     )
 
-    companion object {
-        const val typeName = "Mutation"
-
-    }
-
         data class ProductVariantUpdate(
         /**
          * The updated variant.
@@ -46,9 +41,6 @@ data class ProductVariantShippingResponse(
     list
     }
         )
-        companion object {
-            const val typeName = "ProductVariantUpdatePayload"
-        }
             data class ProductVariant(
             /**
              * Globally unique identifier.
@@ -80,9 +72,6 @@ data class ProductVariantShippingResponse(
                 requiresShipping = OperationGsonBuilder.gson.fromJson(jsonObject.get("requiresShipping"), Boolean::class.java),
                 harmonizedSystemCode = if (!jsonObject.has("harmonizedSystemCode") || jsonObject.get("harmonizedSystemCode").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("harmonizedSystemCode"), String::class.java)
             )
-            companion object {
-                const val typeName = "ProductVariant"
-            }
         }
             data class UserErrors(
             /**
@@ -102,9 +91,6 @@ data class ProductVariantShippingResponse(
         list
         }
             )
-            companion object {
-                const val typeName = "UserError"
-            }
         }
     }
 

--- a/Tests/Resources/ExpectedKotlinCode/Responses/ProductsListResponse.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/ProductsListResponse.kt
@@ -20,11 +20,6 @@ data class ProductsListResponse(
         products = Products(jsonObject.getAsJsonObject("products"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Products(
         /**
          * A list of edges.
@@ -41,9 +36,6 @@ data class ProductsListResponse(
     list
     }
         )
-        companion object {
-            const val typeName = "ProductConnection"
-        }
             data class Edges(
             /**
              * The item at the end of ProductEdge.
@@ -58,9 +50,6 @@ data class ProductsListResponse(
                 node = Node(jsonObject.getAsJsonObject("node")),
                 cursor = OperationGsonBuilder.gson.fromJson(jsonObject.get("cursor"), String::class.java)
             )
-            companion object {
-                const val typeName = "ProductEdge"
-            }
                 data class Node(
                 /**
                  * Globally unique identifier.
@@ -80,9 +69,6 @@ data class ProductsListResponse(
                     title = OperationGsonBuilder.gson.fromJson(jsonObject.get("title"), String::class.java),
                     description = OperationGsonBuilder.gson.fromJson(jsonObject.get("description"), String::class.java)
                 )
-                companion object {
-                    const val typeName = "Product"
-                }
             }
         }
     }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/QueryWithFragmentConditionalResponse.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/QueryWithFragmentConditionalResponse.kt
@@ -21,11 +21,6 @@ data class QueryWithFragmentConditionalResponse(
         shop = Shop(jsonObject.getAsJsonObject("shop"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Shop(
         /**
          * Globally unique identifier.
@@ -37,9 +32,6 @@ data class QueryWithFragmentConditionalResponse(
             id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java),
             fragmentWithConditional = com.shopify.syrup.fragments.FragmentWithConditional(jsonObject)
         )
-        companion object {
-            const val typeName = "Shop"
-        }
     }
 
 }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/ShopQueryResponse.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/ShopQueryResponse.kt
@@ -17,9 +17,4 @@ data class ShopQueryResponse(
         shop = com.shopify.syrup.fragments.Shop(jsonObject)
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
 }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestDeprecatedFieldsResponse.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestDeprecatedFieldsResponse.kt
@@ -21,11 +21,6 @@ data class TestDeprecatedFieldsResponse(
         channels = Channels(jsonObject.getAsJsonObject("channels"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Channels(
         /**
          * A list of edges.
@@ -42,9 +37,6 @@ data class TestDeprecatedFieldsResponse(
     list
     }
         )
-        companion object {
-            const val typeName = "ChannelConnection"
-        }
             data class Edges(
             /**
              * The item at the end of ChannelEdge.
@@ -54,9 +46,6 @@ data class TestDeprecatedFieldsResponse(
             constructor(jsonObject: JsonObject) : this(
                 node = Node(jsonObject.getAsJsonObject("node"))
             )
-            companion object {
-                const val typeName = "ChannelEdge"
-            }
                 data class Node(
                 /**
                  * Underlying app used by the channel.
@@ -66,9 +55,6 @@ data class TestDeprecatedFieldsResponse(
                 constructor(jsonObject: JsonObject) : this(
                     app = App(jsonObject.getAsJsonObject("app"))
                 )
-                companion object {
-                    const val typeName = "Channel"
-                }
                     data class App(
                     /**
                      * Globally unique identifier.
@@ -83,9 +69,6 @@ data class TestDeprecatedFieldsResponse(
                         id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java),
                         icon = Icon(jsonObject.getAsJsonObject("icon"))
                     )
-                    companion object {
-                        const val typeName = "App"
-                    }
                         data class Icon(
                         /**
                          * The location of the image as a URL.
@@ -131,9 +114,6 @@ data class TestDeprecatedFieldsResponse(
                         constructor(jsonObject: JsonObject) : this(
                             src = OperationGsonBuilder.gson.fromJson(jsonObject.get("src"), String::class.java)
                         )
-                        companion object {
-                            const val typeName = "Image"
-                        }
                     }
                 }
             }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestMutation0Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestMutation0Response.kt
@@ -20,11 +20,6 @@ data class TestMutation0Response(
         customerUpdate = if (jsonObject.has("customerUpdate") && !jsonObject.get("customerUpdate").isJsonNull) CustomerUpdate(jsonObject.getAsJsonObject("customerUpdate")) else null
     )
 
-    companion object {
-        const val typeName = "Mutation"
-
-    }
-
         data class CustomerUpdate(
         /**
          * The updated customer.
@@ -34,9 +29,6 @@ data class TestMutation0Response(
         constructor(jsonObject: JsonObject) : this(
             customer = if (jsonObject.has("customer") && !jsonObject.get("customer").isJsonNull) Customer(jsonObject.getAsJsonObject("customer")) else null
         )
-        companion object {
-            const val typeName = "CustomerUpdatePayload"
-        }
             data class Customer(
             /**
              * Globally unique identifier.
@@ -46,9 +38,6 @@ data class TestMutation0Response(
             constructor(jsonObject: JsonObject) : this(
                 id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java)
             )
-            companion object {
-                const val typeName = "Customer"
-            }
         }
     }
 

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery0Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery0Response.kt
@@ -27,11 +27,6 @@ list
 }
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
 data class Nodes(
     val realized: Realized,
     val id: ID 

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery10Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery10Response.kt
@@ -20,11 +20,6 @@ data class TestQuery10Response(
         priceRule = if (jsonObject.has("priceRule") && !jsonObject.get("priceRule").isJsonNull) PriceRule(jsonObject.getAsJsonObject("priceRule")) else null
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class PriceRule(
         /**
          * Globally unique identifier.
@@ -45,9 +40,6 @@ data class TestQuery10Response(
             value = Value(jsonObject.getAsJsonObject("value")),
             valueV2 = ValueV2(jsonObject.getAsJsonObject("valueV2"))
         )
-        companion object {
-            const val typeName = "PriceRule"
-        }
     data class Value(
         val realized: Realized
     ): Response {
@@ -71,9 +63,6 @@ data class TestQuery10Response(
         constructor(jsonObject: JsonObject) : this(
             amount = OperationGsonBuilder.gson.fromJson(jsonObject.get("amount"), BigDecimal::class.java)
         )
-        companion object {
-            const val typeName = "PriceRuleFixedAmountValue"
-        }
     }
     data class PriceRulePercentValue(
         /**
@@ -84,9 +73,6 @@ data class TestQuery10Response(
         constructor(jsonObject: JsonObject) : this(
             percentage = OperationGsonBuilder.gson.fromJson(jsonObject.get("percentage"), Double::class.java)
         )
-        companion object {
-            const val typeName = "PriceRulePercentValue"
-        }
     }
         object Other: Realized()
       }
@@ -114,9 +100,6 @@ data class TestQuery10Response(
         constructor(jsonObject: JsonObject) : this(
             amount = OperationGsonBuilder.gson.fromJson(jsonObject.get("amount"), BigDecimal::class.java)
         )
-        companion object {
-            const val typeName = "MoneyV2"
-        }
     }
     data class PricingPercentageValue(
         /**
@@ -127,9 +110,6 @@ data class TestQuery10Response(
         constructor(jsonObject: JsonObject) : this(
             percentage = OperationGsonBuilder.gson.fromJson(jsonObject.get("percentage"), Double::class.java)
         )
-        companion object {
-            const val typeName = "PricingPercentageValue"
-        }
     }
         object Other: Realized()
       }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery11Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery11Response.kt
@@ -20,11 +20,6 @@ data class TestQuery11Response(
         node = if (jsonObject.has("node") && !jsonObject.get("node").isJsonNull) Node(jsonObject.getAsJsonObject("node")) else null
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
 data class Node(
     val realized: Realized
 ): Response {
@@ -53,9 +48,6 @@ data class Product(
         id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java),
         collections = Collections(jsonObject.getAsJsonObject("collections"))
     )
-    companion object {
-        const val typeName = "Product"
-    }
         data class Collections(
         /**
          * A list of edges.
@@ -72,9 +64,6 @@ data class Product(
     list
     }
         )
-        companion object {
-            const val typeName = "CollectionConnection"
-        }
             data class Edges(
             /**
              * The item at the end of CollectionEdge.
@@ -84,9 +73,6 @@ data class Product(
             constructor(jsonObject: JsonObject) : this(
                 node = Node(jsonObject.getAsJsonObject("node"))
             )
-            companion object {
-                const val typeName = "CollectionEdge"
-            }
                 data class Node(
                 /**
                  * Globally unique identifier.
@@ -101,9 +87,6 @@ data class Product(
                     id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java),
                     title = OperationGsonBuilder.gson.fromJson(jsonObject.get("title"), String::class.java)
                 )
-                companion object {
-                    const val typeName = "Collection"
-                }
             }
         }
     }
@@ -117,9 +100,6 @@ data class ProductOption(
     constructor(jsonObject: JsonObject) : this(
         id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java)
     )
-    companion object {
-        const val typeName = "ProductOption"
-    }
 }
     object Other: Realized()
 }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery1Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery1Response.kt
@@ -20,11 +20,6 @@ data class TestQuery1Response(
         shop = Shop(jsonObject.getAsJsonObject("shop"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Shop(
         /**
          * Globally unique identifier.
@@ -80,9 +75,6 @@ data class TestQuery1Response(
     },
             paymentSettings = PaymentSettings(jsonObject.getAsJsonObject("paymentSettings"))
         )
-        companion object {
-            const val typeName = "Shop"
-        }
             data class BillingAddress(
             /**
              * The name of the city, district, village, or town.
@@ -107,9 +99,6 @@ data class TestQuery1Response(
                 latitude = if (!jsonObject.has("latitude") || jsonObject.get("latitude").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("latitude"), Double::class.java),
                 longitude = if (!jsonObject.has("longitude") || jsonObject.get("longitude").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("longitude"), Double::class.java)
             )
-            companion object {
-                const val typeName = "MailingAddress"
-            }
         }
             data class Alerts(
             /**
@@ -120,9 +109,6 @@ data class TestQuery1Response(
             constructor(jsonObject: JsonObject) : this(
                 description = OperationGsonBuilder.gson.fromJson(jsonObject.get("description"), String::class.java)
             )
-            companion object {
-                const val typeName = "ShopAlert"
-            }
         }
             data class PaymentSettings(
             /**
@@ -137,9 +123,6 @@ data class TestQuery1Response(
         list
         }
             )
-            companion object {
-                const val typeName = "PaymentSettings"
-            }
         }
     }
 

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery2Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery2Response.kt
@@ -20,11 +20,6 @@ data class TestQuery2Response(
         shop = Shop(jsonObject.getAsJsonObject("shop"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Shop(
         /**
          * The shop's name.
@@ -57,9 +52,6 @@ data class TestQuery2Response(
     list
     }
         )
-        companion object {
-            const val typeName = "Shop"
-        }
             data class Alerts(
             /**
              * Button in the alert that links to related information.
@@ -74,9 +66,6 @@ data class TestQuery2Response(
                 action = Action(jsonObject.getAsJsonObject("action")),
                 description = OperationGsonBuilder.gson.fromJson(jsonObject.get("description"), String::class.java)
             )
-            companion object {
-                const val typeName = "ShopAlert"
-            }
                 data class Action(
                 /**
                  * Action title.
@@ -91,9 +80,6 @@ data class TestQuery2Response(
                     title = OperationGsonBuilder.gson.fromJson(jsonObject.get("title"), String::class.java),
                     url = OperationGsonBuilder.gson.fromJson(jsonObject.get("url"), String::class.java)
                 )
-                companion object {
-                    const val typeName = "ShopAlertAction"
-                }
             }
         }
     }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery3Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery3Response.kt
@@ -20,11 +20,6 @@ data class TestQuery3Response(
         customer = if (jsonObject.has("customer") && !jsonObject.get("customer").isJsonNull) Customer(jsonObject.getAsJsonObject("customer")) else null
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Customer(
         /**
          * A list of addresses associated with the customer.
@@ -46,9 +41,6 @@ data class TestQuery3Response(
     },
             defaultAddress = if (jsonObject.has("defaultAddress") && !jsonObject.get("defaultAddress").isJsonNull) DefaultAddress(jsonObject.getAsJsonObject("defaultAddress")) else null
         )
-        companion object {
-            const val typeName = "Customer"
-        }
             data class Addresses(
             /**
              * The name of the country.
@@ -58,9 +50,6 @@ data class TestQuery3Response(
             constructor(jsonObject: JsonObject) : this(
                 country = if (!jsonObject.has("country") || jsonObject.get("country").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("country"), String::class.java)
             )
-            companion object {
-                const val typeName = "MailingAddress"
-            }
         }
             data class DefaultAddress(
             /**
@@ -81,9 +70,6 @@ data class TestQuery3Response(
                 longitude = if (!jsonObject.has("longitude") || jsonObject.get("longitude").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("longitude"), Double::class.java),
                 latitude = if (!jsonObject.has("latitude") || jsonObject.get("latitude").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("latitude"), Double::class.java)
             )
-            companion object {
-                const val typeName = "MailingAddress"
-            }
         }
     }
 

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery4Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery4Response.kt
@@ -20,11 +20,6 @@ data class TestQuery4Response(
         shop = Shop(jsonObject.getAsJsonObject("shop"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Shop(
         /**
          * Globally unique identifier.
@@ -39,9 +34,6 @@ data class TestQuery4Response(
             id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java),
             availableChannelApps = AvailableChannelApps(jsonObject.getAsJsonObject("availableChannelApps"))
         )
-        companion object {
-            const val typeName = "Shop"
-        }
             data class AvailableChannelApps(
             /**
              * A list of edges.
@@ -58,9 +50,6 @@ data class TestQuery4Response(
         list
         }
             )
-            companion object {
-                const val typeName = "AppConnection"
-            }
                 data class Edges(
                 /**
                  * The item at the end of AppEdge.
@@ -70,9 +59,6 @@ data class TestQuery4Response(
                 constructor(jsonObject: JsonObject) : this(
                     node = Node(jsonObject.getAsJsonObject("node"))
                 )
-                companion object {
-                    const val typeName = "AppEdge"
-                }
                     data class Node(
                     /**
                      * Globally unique identifier.
@@ -87,9 +73,6 @@ data class TestQuery4Response(
                         id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java),
                         title = OperationGsonBuilder.gson.fromJson(jsonObject.get("title"), String::class.java)
                     )
-                    companion object {
-                        const val typeName = "App"
-                    }
                 }
             }
         }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery5Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery5Response.kt
@@ -20,11 +20,6 @@ data class TestQuery5Response(
         shop = Shop(jsonObject.getAsJsonObject("shop"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Shop(
         /**
          * The shop's name.
@@ -61,9 +56,6 @@ data class TestQuery5Response(
     list
     }
         )
-        companion object {
-            const val typeName = "Shop"
-        }
             data class BillingAddress(
             /**
              * The name of the city, district, village, or town.
@@ -88,9 +80,6 @@ data class TestQuery5Response(
                 latitude = if (!jsonObject.has("latitude") || jsonObject.get("latitude").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("latitude"), Double::class.java),
                 longitude = if (!jsonObject.has("longitude") || jsonObject.get("longitude").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("longitude"), Double::class.java)
             )
-            companion object {
-                const val typeName = "MailingAddress"
-            }
         }
             data class FulfillmentServices(
             /**
@@ -106,9 +95,6 @@ data class TestQuery5Response(
                 serviceName = OperationGsonBuilder.gson.fromJson(jsonObject.get("serviceName"), String::class.java),
                 handle = OperationGsonBuilder.gson.fromJson(jsonObject.get("handle"), String::class.java)
             )
-            companion object {
-                const val typeName = "FulfillmentService"
-            }
         }
     }
 

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery6Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery6Response.kt
@@ -20,11 +20,6 @@ data class TestQuery6Response(
         shop = Shop(jsonObject.getAsJsonObject("shop"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Shop(
         /**
          * The shop's name.
@@ -67,9 +62,6 @@ data class TestQuery6Response(
     },
             orders = Orders(jsonObject.getAsJsonObject("orders"))
         )
-        companion object {
-            const val typeName = "Shop"
-        }
             data class BillingAddress(
             /**
              * The name of the city, district, village, or town.
@@ -94,9 +86,6 @@ data class TestQuery6Response(
                 latitude = if (!jsonObject.has("latitude") || jsonObject.get("latitude").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("latitude"), Double::class.java),
                 longitude = if (!jsonObject.has("longitude") || jsonObject.get("longitude").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("longitude"), Double::class.java)
             )
-            companion object {
-                const val typeName = "MailingAddress"
-            }
         }
             data class FulfillmentServices(
             /**
@@ -112,9 +101,6 @@ data class TestQuery6Response(
                 serviceName = OperationGsonBuilder.gson.fromJson(jsonObject.get("serviceName"), String::class.java),
                 handle = OperationGsonBuilder.gson.fromJson(jsonObject.get("handle"), String::class.java)
             )
-            companion object {
-                const val typeName = "FulfillmentService"
-            }
         }
             data class Orders(
             /**
@@ -132,9 +118,6 @@ data class TestQuery6Response(
         list
         }
             )
-            companion object {
-                const val typeName = "OrderConnection"
-            }
                 data class Edges(
                 /**
                  * The item at the end of OrderEdge.
@@ -144,9 +127,6 @@ data class TestQuery6Response(
                 constructor(jsonObject: JsonObject) : this(
                     node = Node(jsonObject.getAsJsonObject("node"))
                 )
-                companion object {
-                    const val typeName = "OrderEdge"
-                }
                     data class Node(
                     /**
                      * Unique identifier for the order that appears on the order.
@@ -164,9 +144,6 @@ data class TestQuery6Response(
                         name = OperationGsonBuilder.gson.fromJson(jsonObject.get("name"), String::class.java),
                         displayFulfillmentStatus = OrderDisplayFulfillmentStatus.safeValueOf(jsonObject.decodeEnumValue<OrderDisplayFulfillmentStatus>("displayFulfillmentStatus"))
                     )
-                    companion object {
-                        const val typeName = "Order"
-                    }
                 }
             }
         }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery7Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery7Response.kt
@@ -20,11 +20,6 @@ data class TestQuery7Response(
         shop = Shop(jsonObject.getAsJsonObject("shop"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Shop(
         /**
          * The shop's name.
@@ -67,9 +62,6 @@ data class TestQuery7Response(
     },
             orders = Orders(jsonObject.getAsJsonObject("orders"))
         )
-        companion object {
-            const val typeName = "Shop"
-        }
             data class BillingAddress(
             /**
              * The name of the city, district, village, or town.
@@ -94,9 +86,6 @@ data class TestQuery7Response(
                 latitude = if (!jsonObject.has("latitude") || jsonObject.get("latitude").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("latitude"), Double::class.java),
                 longitude = if (!jsonObject.has("longitude") || jsonObject.get("longitude").isJsonNull) null else OperationGsonBuilder.gson.fromJson(jsonObject.get("longitude"), Double::class.java)
             )
-            companion object {
-                const val typeName = "MailingAddress"
-            }
         }
             data class FulfillmentServices(
             /**
@@ -112,9 +101,6 @@ data class TestQuery7Response(
                 serviceName = OperationGsonBuilder.gson.fromJson(jsonObject.get("serviceName"), String::class.java),
                 handle = OperationGsonBuilder.gson.fromJson(jsonObject.get("handle"), String::class.java)
             )
-            companion object {
-                const val typeName = "FulfillmentService"
-            }
         }
             data class Orders(
             /**
@@ -132,9 +118,6 @@ data class TestQuery7Response(
         list
         }
             )
-            companion object {
-                const val typeName = "OrderConnection"
-            }
                 data class Edges(
                 /**
                  * The item at the end of OrderEdge.
@@ -144,9 +127,6 @@ data class TestQuery7Response(
                 constructor(jsonObject: JsonObject) : this(
                     node = Node(jsonObject.getAsJsonObject("node"))
                 )
-                companion object {
-                    const val typeName = "OrderEdge"
-                }
                     data class Node(
                     /**
                      * Unique identifier for the order that appears on the order.
@@ -176,9 +156,6 @@ data class TestQuery7Response(
                 list
                 }
                     )
-                    companion object {
-                        const val typeName = "Order"
-                    }
                         data class Fulfillments(
                         /**
                          * Human readable reference identifier for this fulfillment.
@@ -213,9 +190,6 @@ data class TestQuery7Response(
                             displayStatus = if (jsonObject.has("displayStatus") && !jsonObject.get("displayStatus").isJsonNull) FulfillmentDisplayStatus.safeValueOf(jsonObject.decodeEnumValue<FulfillmentDisplayStatus>("displayStatus")) else null,
                             events = Events(jsonObject.getAsJsonObject("events"))
                         )
-                        companion object {
-                            const val typeName = "Fulfillment"
-                        }
                             data class Events(
                             /**
                              * A list of edges.
@@ -232,9 +206,6 @@ data class TestQuery7Response(
                         list
                         }
                             )
-                            companion object {
-                                const val typeName = "FulfillmentEventConnection"
-                            }
                                 data class Edges(
                                 /**
                                  * The item at the end of FulfillmentEventEdge.
@@ -244,9 +215,6 @@ data class TestQuery7Response(
                                 constructor(jsonObject: JsonObject) : this(
                                     node = Node(jsonObject.getAsJsonObject("node"))
                                 )
-                                companion object {
-                                    const val typeName = "FulfillmentEventEdge"
-                                }
                                     data class Node(
                                     /**
                                      * The status of this fulfillment event.
@@ -256,9 +224,6 @@ data class TestQuery7Response(
                                     constructor(jsonObject: JsonObject) : this(
                                         status = FulfillmentEventStatus.safeValueOf(jsonObject.decodeEnumValue<FulfillmentEventStatus>("status"))
                                     )
-                                    companion object {
-                                        const val typeName = "FulfillmentEvent"
-                                    }
                                 }
                             }
                         }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery8Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery8Response.kt
@@ -20,11 +20,6 @@ data class TestQuery8Response(
         shop = Shop(jsonObject.getAsJsonObject("shop"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Shop(
         /**
          * Globally unique identifier.
@@ -46,9 +41,6 @@ data class TestQuery8Response(
             firstProduct = FirstProduct(jsonObject.getAsJsonObject("firstProduct")),
             lastProduct = LastProduct(jsonObject.getAsJsonObject("lastProduct"))
         )
-        companion object {
-            const val typeName = "Shop"
-        }
             data class FirstProduct(
             /**
              * A list of edges.
@@ -65,9 +57,6 @@ data class TestQuery8Response(
         list
         }
             )
-            companion object {
-                const val typeName = "ProductConnection"
-            }
                 data class Edges(
                 /**
                  * A cursor for use in pagination.
@@ -82,9 +71,6 @@ data class TestQuery8Response(
                     cursor = OperationGsonBuilder.gson.fromJson(jsonObject.get("cursor"), String::class.java),
                     node = Node(jsonObject.getAsJsonObject("node"))
                 )
-                companion object {
-                    const val typeName = "ProductEdge"
-                }
                     data class Node(
                     /**
                      * The title of the product.
@@ -94,9 +80,6 @@ data class TestQuery8Response(
                     constructor(jsonObject: JsonObject) : this(
                         title = OperationGsonBuilder.gson.fromJson(jsonObject.get("title"), String::class.java)
                     )
-                    companion object {
-                        const val typeName = "Product"
-                    }
                 }
             }
         }
@@ -116,9 +99,6 @@ data class TestQuery8Response(
         list
         }
             )
-            companion object {
-                const val typeName = "ProductConnection"
-            }
                 data class Edges(
                 /**
                  * A cursor for use in pagination.
@@ -133,9 +113,6 @@ data class TestQuery8Response(
                     cursor = OperationGsonBuilder.gson.fromJson(jsonObject.get("cursor"), String::class.java),
                     node = Node(jsonObject.getAsJsonObject("node"))
                 )
-                companion object {
-                    const val typeName = "ProductEdge"
-                }
                     data class Node(
                     /**
                      * The title of the product.
@@ -145,9 +122,6 @@ data class TestQuery8Response(
                     constructor(jsonObject: JsonObject) : this(
                         title = OperationGsonBuilder.gson.fromJson(jsonObject.get("title"), String::class.java)
                     )
-                    companion object {
-                        const val typeName = "Product"
-                    }
                 }
             }
         }

--- a/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery9Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/TestQuery9Response.kt
@@ -21,11 +21,6 @@ data class TestQuery9Response(
         shop = Shop(jsonObject.getAsJsonObject("shop"))
     )
 
-    companion object {
-        const val typeName = "QueryRoot"
-
-    }
-
         data class Shop(
         /**
          * Customer accounts associated to the shop.
@@ -36,9 +31,6 @@ data class TestQuery9Response(
         constructor(jsonObject: JsonObject) : this(
             customers = Customers(jsonObject.getAsJsonObject("customers"))
         )
-        companion object {
-            const val typeName = "Shop"
-        }
             data class Customers(
             /**
              * A list of edges.
@@ -55,9 +47,6 @@ data class TestQuery9Response(
         list
         }
             )
-            companion object {
-                const val typeName = "CustomerConnection"
-            }
                 data class Edges(
                 /**
                  * The item at the end of CustomerEdge.
@@ -67,9 +56,6 @@ data class TestQuery9Response(
                 constructor(jsonObject: JsonObject) : this(
                     node = Node(jsonObject.getAsJsonObject("node"))
                 )
-                companion object {
-                    const val typeName = "CustomerEdge"
-                }
                     data class Node(
                     /**
                      * Globally unique identifier.
@@ -81,9 +67,6 @@ data class TestQuery9Response(
                         id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java),
                         basicFragment = com.shopify.syrup.fragments.BasicFragment(jsonObject)
                     )
-                    companion object {
-                        const val typeName = "Customer"
-                    }
                 }
             }
         }


### PR DESCRIPTION
This is part 3 of generated code cleanup to improve build times.

It seems these companion objects are completely unused and negatively affect build times.