### PR TITLE
Decode shouldn't use inout

### DIFF
--- a/Templates/Swift/GraphApi.stencil
+++ b/Templates/Swift/GraphApi.stencil
@@ -108,7 +108,7 @@ open class BaseCustomScalarResolver {
 		return accumulator
 	}
 
-	public func decode<T, R: Decodable, K>(_ type: Optional<T>.Type, rawValueType: R.Type, forKey key: K, container: inout KeyedDecodingContainer<K>, resolver: (R) throws -> T) throws -> Optional<T> {
+	public func decode<T, R: Decodable, K>(_ type: Optional<T>.Type, rawValueType: R.Type, forKey key: K, container: KeyedDecodingContainer<K>, resolver: (R) throws -> T) throws -> Optional<T> {
 		guard let value = try container.decodeIfPresent(R.self, forKey: key) else {
 			return nil
 		}

--- a/Tests/Resources/ExpectedSwiftCode/GraphApi.swift
+++ b/Tests/Resources/ExpectedSwiftCode/GraphApi.swift
@@ -109,7 +109,7 @@ open class BaseCustomScalarResolver {
 		return accumulator
 	}
 
-	public func decode<T, R: Decodable, K>(_ type: Optional<T>.Type, rawValueType: R.Type, forKey key: K, container: inout KeyedDecodingContainer<K>, resolver: (R) throws -> T) throws -> Optional<T> {
+	public func decode<T, R: Decodable, K>(_ type: Optional<T>.Type, rawValueType: R.Type, forKey key: K, container: KeyedDecodingContainer<K>, resolver: (R) throws -> T) throws -> Optional<T> {
 		guard let value = try container.decodeIfPresent(R.self, forKey: key) else {
 			return nil
 		}


### PR DESCRIPTION
The generated code for decoding a value had an incorrect function signature that could cause optional values to be decoded as non-optionals. This could cause decoding of a response to fail if the value from the API was null.

In the GraphApi file, the decode functions take the `KeyedDecodingContainer` directly. The encode functions are the ones that take a `inout` parameter. It looks like this was a mistake to have this specific decode function use a `inout`.