### PR TITLE
Use published syrup-gradle plugin in Kotlin sample

### DIFF
--- a/samples/kotlin/build.gradle
+++ b/samples/kotlin/build.gradle
@@ -1,6 +1,12 @@
 buildscript {
+    repositories {
+        maven {
+            url  "https://dl.bintray.com/shopify/shopify-java"
+        }
+    }
+
     dependencies {
-        classpath files("${project.rootDir.path}/syrup-plugin-0.2.jar")
+        classpath 'com.shopify.syrup:syrup-gradle:0.2'
     }
 }
 

--- a/samples/kotlin/src/main/java/com/shopify/syrup/fragments/MovieFragment.kt
+++ b/samples/kotlin/src/main/java/com/shopify/syrup/fragments/MovieFragment.kt
@@ -35,33 +35,37 @@ data class MovieFragment(
 
         fun getSelections(operationVariables: Map<String, String>): List<Selection> {
             return listOf<Selection>(
-Selection(
-name = "title",
-type = "String",
-cacheKey = "title",
-passedGID = null,
-backingGIDReference = null,
-typeCondition = "Film",
-shouldSkipBasedOnConditionalDirective = false,
-selections = listOf<Selection>()),
-Selection(
-name = "director",
-type = "String",
-cacheKey = "director",
-passedGID = null,
-backingGIDReference = null,
-typeCondition = "Film",
-shouldSkipBasedOnConditionalDirective = false,
-selections = listOf<Selection>()),
-Selection(
-name = "openingCrawl",
-type = "String",
-cacheKey = "openingCrawl",
-passedGID = null,
-backingGIDReference = null,
-typeCondition = "Film",
-shouldSkipBasedOnConditionalDirective = false,
-selections = listOf<Selection>()))
+                Selection(
+                    name = "title",
+                    type = "String",
+                    cacheKey = "title",
+                    passedGID = null,
+                    backingGIDReference = null,
+                    typeCondition = "Film",
+                    shouldSkipBasedOnConditionalDirective = false,
+                    selections = listOf<Selection>()
+                ),
+                Selection(
+                    name = "director",
+                    type = "String",
+                    cacheKey = "director",
+                    passedGID = null,
+                    backingGIDReference = null,
+                    typeCondition = "Film",
+                    shouldSkipBasedOnConditionalDirective = false,
+                    selections = listOf<Selection>()
+                ),
+                Selection(
+                    name = "openingCrawl",
+                    type = "String",
+                    cacheKey = "openingCrawl",
+                    passedGID = null,
+                    backingGIDReference = null,
+                    typeCondition = "Film",
+                    shouldSkipBasedOnConditionalDirective = false,
+                    selections = listOf<Selection>()
+                )
+            )
         }
     }
 }

--- a/samples/kotlin/src/main/java/com/shopify/syrup/queries/FilmsQuery.kt
+++ b/samples/kotlin/src/main/java/com/shopify/syrup/queries/FilmsQuery.kt
@@ -30,31 +30,37 @@ class FilmsQuery() : Query<FilmsResponse> {
     val operationVariables = mapOf<String, String>()
 
     override val selections = listOf<Selection>(
-Selection(
-name = "allFilms",
-type = "FilmsConnection",
-cacheKey = "allFilms",
-passedGID = null,
-backingGIDReference = null,
-typeCondition = "Root",
-shouldSkipBasedOnConditionalDirective = false,
-selections = listOf<Selection>(
-Selection(
-name = "edges",
-type = "FilmsEdge",
-cacheKey = "edges",
-passedGID = null,
-backingGIDReference = null,
-typeCondition = "FilmsConnection",
-shouldSkipBasedOnConditionalDirective = false,
-selections = listOf<Selection>(
-Selection(
-name = "node",
-type = "Film",
-cacheKey = "node",
-passedGID = null,
-backingGIDReference = null,
-typeCondition = "FilmsEdge",
-shouldSkipBasedOnConditionalDirective = false,
-selections = listOf<Selection>() + MovieFragment.getSelections(operationVariables).map { it.copy(typeCondition = "Film") }))))))
+        Selection(
+            name = "allFilms",
+            type = "FilmsConnection",
+            cacheKey = "allFilms",
+            passedGID = null,
+            backingGIDReference = null,
+            typeCondition = "Root",
+            shouldSkipBasedOnConditionalDirective = false,
+            selections = listOf<Selection>(
+                Selection(
+                    name = "edges",
+                    type = "FilmsEdge",
+                    cacheKey = "edges",
+                    passedGID = null,
+                    backingGIDReference = null,
+                    typeCondition = "FilmsConnection",
+                    shouldSkipBasedOnConditionalDirective = false,
+                    selections = listOf<Selection>(
+                        Selection(
+                            name = "node",
+                            type = "Film",
+                            cacheKey = "node",
+                            passedGID = null,
+                            backingGIDReference = null,
+                            typeCondition = "FilmsEdge",
+                            shouldSkipBasedOnConditionalDirective = false,
+                            selections = listOf<Selection>() + MovieFragment.getSelections(operationVariables).map { it.copy(typeCondition = "Film") }
+                        )
+                    )
+                )
+            )
+        )
+    )
 }

--- a/samples/kotlin/src/main/java/com/shopify/syrup/responses/FilmsResponse.kt
+++ b/samples/kotlin/src/main/java/com/shopify/syrup/responses/FilmsResponse.kt
@@ -20,40 +20,40 @@ data class FilmsResponse(
         const val typeName = "Root"
     }
 
-        data class AllFilms(
-            /**    
-             * A list of edges.    
-             */    
-            val edges: ArrayList<Edges?>?
-        ) : Response {
+    data class AllFilms(
+        /**    
+         * A list of edges.    
+         */    
+        val edges: ArrayList<Edges?>?
+    ) : Response {
         constructor(jsonObject: JsonObject) : this(
             edges = if (!jsonObject.has("edges") || jsonObject.get("edges").isJsonNull) null else jsonObject.getAsJsonArray("edges").run {
-    val list: ArrayList<Edges?>? = ArrayList()
-    this.forEach {
-            val edges = if (it.isJsonNull) null else Edges(it.asJsonObject)
-            list?.add(edges)
-    }
-    list
-    }
+                val list: ArrayList<Edges?>? = ArrayList()
+                this.forEach {
+                    val edges = if (it.isJsonNull) null else Edges(it.asJsonObject)
+                    list?.add(edges)
+                }
+                list
+            }
         )
         companion object {
             const val typeName = "FilmsConnection"
         }
-            data class Edges(
-                /**    
-                 * The item at the end of the edge    
-                 */    
-                val node: Node?
-            ) : Response {
+        data class Edges(
+            /**    
+             * The item at the end of the edge    
+             */    
+            val node: Node?
+        ) : Response {
             constructor(jsonObject: JsonObject) : this(
                 node = if (jsonObject.has("node") && !jsonObject.get("node").isJsonNull) Node(jsonObject.getAsJsonObject("node")) else null
             )
             companion object {
                 const val typeName = "FilmsEdge"
             }
-                data class Node(
-                    val movieFragment: com.shopify.syrup.fragments.MovieFragment
-                ) : Response {
+            data class Node(
+                val movieFragment: com.shopify.syrup.fragments.MovieFragment
+            ) : Response {
                 constructor(jsonObject: JsonObject) : this(
                     movieFragment = com.shopify.syrup.fragments.MovieFragment(jsonObject)
                 )


### PR DESCRIPTION
Deletes the committed JAR and moves the sample project to the published version of `syrup-gradle`.

Regenerates the models with latest syrup (ktlint format fixes).