### PR TITLE
Enforce enums to use a sorted order

### DIFF
--- a/Sources/SyrupCore/Generator/Renderer.swift
+++ b/Sources/SyrupCore/Generator/Renderer.swift
@@ -133,8 +133,7 @@ open class Renderer {
 		for enumType in intermediateRepresentation.referencedEnums {
 			let context: [String: Any] = [
 				"moduleName": config.project.moduleName,
-				"enumType": enumType,
-				"sortedEnumValues": enumType.values.sorted { lhs, rhs in lhs.value < rhs.value }
+				"enumType": enumType
 			]
 			rendered.append(try render(template: "EnumType", asFile: true, context: context))
 		}

--- a/Sources/SyrupCore/Generator/Renderer.swift
+++ b/Sources/SyrupCore/Generator/Renderer.swift
@@ -133,7 +133,8 @@ open class Renderer {
 		for enumType in intermediateRepresentation.referencedEnums {
 			let context: [String: Any] = [
 				"moduleName": config.project.moduleName,
-				"enumType": enumType
+				"enumType": enumType,
+				"sortedEnumValues": enumType.values.sorted { lhs, rhs in lhs.value < rhs.value }
 			]
 			rendered.append(try render(template: "EnumType", asFile: true, context: context))
 		}

--- a/Sources/SyrupCore/GraphQL/IntermediateRepresentationVisitor.swift
+++ b/Sources/SyrupCore/GraphQL/IntermediateRepresentationVisitor.swift
@@ -328,7 +328,7 @@ class IntermediateRepresentationVisitor: GraphQLBaseVisitor {
 		let name = schemaType.name
 		let topLevelType = schema.type(named: name)
 		
-		let enumValues = topLevelType.enumValues.map {
+		let enumValues = topLevelType.enumValues.sorted(by: { $0.name < $1.name }).map {
 			return IntermediateRepresentation.EnumType.Value(
 				value: $0.name,
 				attributes: IntermediateRepresentation.Attributes(

--- a/Templates/Swift/EnumType.stencil
+++ b/Templates/Swift/EnumType.stencil
@@ -3,7 +3,7 @@
 {% block content %}
 	{% with enumType.attributes as attributes %}{% include "Helpers/Attributes.stencil" %}{% endwith %}
 	enum {{ enumType.name }}: String, Codable {
-		{% for enumValue in sortedEnumValues %}
+		{% for enumValue in enumType.values %}
 			{% with enumValue.attributes as attributes %}{% include "Helpers/Attributes.stencil" %}{% endwith %}
 			case {{ enumValue.value|camelCased|escapeReservedWord }} = "{{ enumValue.value }}"
 		{% endfor %}

--- a/Templates/Swift/EnumType.stencil
+++ b/Templates/Swift/EnumType.stencil
@@ -3,7 +3,7 @@
 {% block content %}
 	{% with enumType.attributes as attributes %}{% include "Helpers/Attributes.stencil" %}{% endwith %}
 	enum {{ enumType.name }}: String, Codable {
-		{% for enumValue in enumType.values %}
+		{% for enumValue in sortedEnumValues %}
 			{% with enumValue.attributes as attributes %}{% include "Helpers/Attributes.stencil" %}{% endwith %}
 			case {{ enumValue.value|camelCased|escapeReservedWord }} = "{{ enumValue.value }}"
 		{% endfor %}

--- a/Tests/Resources/ExpectedKotlinCode/Enums/CollectionRuleColumn.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/CollectionRuleColumn.kt
@@ -10,6 +10,12 @@ import javax.annotation.Generated
 enum class CollectionRuleColumn(val value: String) {
 
     /**
+     * The `is_price_reduced` attribute.
+     */
+    @SerializedName("IS_PRICE_REDUCED")
+    IS_PRICE_REDUCED("IS_PRICE_REDUCED"),
+
+    /**
      * The `tag` attribute.
      */
     @SerializedName("TAG")
@@ -28,34 +34,10 @@ enum class CollectionRuleColumn(val value: String) {
     TYPE("TYPE"),
 
     /**
-     * The `vendor` attribute.
-     */
-    @SerializedName("VENDOR")
-    VENDOR("VENDOR"),
-
-    /**
-     * The `variant_price` attribute.
-     */
-    @SerializedName("VARIANT_PRICE")
-    VARIANT_PRICE("VARIANT_PRICE"),
-
-    /**
-     * The `is_price_reduced` attribute.
-     */
-    @SerializedName("IS_PRICE_REDUCED")
-    IS_PRICE_REDUCED("IS_PRICE_REDUCED"),
-
-    /**
      * The `variant_compare_at_price` attribute.
      */
     @SerializedName("VARIANT_COMPARE_AT_PRICE")
     VARIANT_COMPARE_AT_PRICE("VARIANT_COMPARE_AT_PRICE"),
-
-    /**
-     * The `variant_weight` attribute.
-     */
-    @SerializedName("VARIANT_WEIGHT")
-    VARIANT_WEIGHT("VARIANT_WEIGHT"),
 
     /**
      * The `variant_inventory` attribute.
@@ -64,10 +46,28 @@ enum class CollectionRuleColumn(val value: String) {
     VARIANT_INVENTORY("VARIANT_INVENTORY"),
 
     /**
+     * The `variant_price` attribute.
+     */
+    @SerializedName("VARIANT_PRICE")
+    VARIANT_PRICE("VARIANT_PRICE"),
+
+    /**
      * The `variant_title` attribute.
      */
     @SerializedName("VARIANT_TITLE")
     VARIANT_TITLE("VARIANT_TITLE"),
+
+    /**
+     * The `variant_weight` attribute.
+     */
+    @SerializedName("VARIANT_WEIGHT")
+    VARIANT_WEIGHT("VARIANT_WEIGHT"),
+
+    /**
+     * The `vendor` attribute.
+     */
+    @SerializedName("VENDOR")
+    VENDOR("VENDOR"),
 
     UNKNOWN_SYRUP_ENUM("UNKNOWN_SYRUP_ENUM");
 

--- a/Tests/Resources/ExpectedKotlinCode/Enums/CountryCode.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/CountryCode.kt
@@ -10,46 +10,22 @@ import javax.annotation.Generated
 enum class CountryCode(val value: String) {
 
     /**
-     * Afghanistan.
-     */
-    @SerializedName("AF")
-    AF("AF"),
-
-    /**
-     * Aland Islands.
-     */
-    @SerializedName("AX")
-    AX("AX"),
-
-    /**
-     * Albania.
-     */
-    @SerializedName("AL")
-    AL("AL"),
-
-    /**
-     * Algeria.
-     */
-    @SerializedName("DZ")
-    DZ("DZ"),
-
-    /**
      * Andorra.
      */
     @SerializedName("AD")
     AD("AD"),
 
     /**
-     * Angola.
+     * United Arab Emirates.
      */
-    @SerializedName("AO")
-    AO("AO"),
+    @SerializedName("AE")
+    AE("AE"),
 
     /**
-     * Anguilla.
+     * Afghanistan.
      */
-    @SerializedName("AI")
-    AI("AI"),
+    @SerializedName("AF")
+    AF("AF"),
 
     /**
      * Antigua And Barbuda.
@@ -58,10 +34,16 @@ enum class CountryCode(val value: String) {
     AG("AG"),
 
     /**
-     * Argentina.
+     * Anguilla.
      */
-    @SerializedName("AR")
-    AR("AR"),
+    @SerializedName("AI")
+    AI("AI"),
+
+    /**
+     * Albania.
+     */
+    @SerializedName("AL")
+    AL("AL"),
 
     /**
      * Armenia.
@@ -70,16 +52,22 @@ enum class CountryCode(val value: String) {
     AM("AM"),
 
     /**
-     * Aruba.
+     * Netherlands Antilles.
      */
-    @SerializedName("AW")
-    AW("AW"),
+    @SerializedName("AN")
+    AN("AN"),
 
     /**
-     * Australia.
+     * Angola.
      */
-    @SerializedName("AU")
-    AU("AU"),
+    @SerializedName("AO")
+    AO("AO"),
+
+    /**
+     * Argentina.
+     */
+    @SerializedName("AR")
+    AR("AR"),
 
     /**
      * Austria.
@@ -88,76 +76,28 @@ enum class CountryCode(val value: String) {
     AT("AT"),
 
     /**
+     * Australia.
+     */
+    @SerializedName("AU")
+    AU("AU"),
+
+    /**
+     * Aruba.
+     */
+    @SerializedName("AW")
+    AW("AW"),
+
+    /**
+     * Aland Islands.
+     */
+    @SerializedName("AX")
+    AX("AX"),
+
+    /**
      * Azerbaijan.
      */
     @SerializedName("AZ")
     AZ("AZ"),
-
-    /**
-     * Bahamas.
-     */
-    @SerializedName("BS")
-    BS("BS"),
-
-    /**
-     * Bahrain.
-     */
-    @SerializedName("BH")
-    BH("BH"),
-
-    /**
-     * Bangladesh.
-     */
-    @SerializedName("BD")
-    BD("BD"),
-
-    /**
-     * Barbados.
-     */
-    @SerializedName("BB")
-    BB("BB"),
-
-    /**
-     * Belarus.
-     */
-    @SerializedName("BY")
-    BY("BY"),
-
-    /**
-     * Belgium.
-     */
-    @SerializedName("BE")
-    BE("BE"),
-
-    /**
-     * Belize.
-     */
-    @SerializedName("BZ")
-    BZ("BZ"),
-
-    /**
-     * Benin.
-     */
-    @SerializedName("BJ")
-    BJ("BJ"),
-
-    /**
-     * Bermuda.
-     */
-    @SerializedName("BM")
-    BM("BM"),
-
-    /**
-     * Bhutan.
-     */
-    @SerializedName("BT")
-    BT("BT"),
-
-    /**
-     * Bolivia.
-     */
-    @SerializedName("BO")
-    BO("BO"),
 
     /**
      * Bosnia And Herzegovina.
@@ -166,40 +106,22 @@ enum class CountryCode(val value: String) {
     BA("BA"),
 
     /**
-     * Botswana.
+     * Barbados.
      */
-    @SerializedName("BW")
-    BW("BW"),
+    @SerializedName("BB")
+    BB("BB"),
 
     /**
-     * Bouvet Island.
+     * Bangladesh.
      */
-    @SerializedName("BV")
-    BV("BV"),
+    @SerializedName("BD")
+    BD("BD"),
 
     /**
-     * Brazil.
+     * Belgium.
      */
-    @SerializedName("BR")
-    BR("BR"),
-
-    /**
-     * British Indian Ocean Territory.
-     */
-    @SerializedName("IO")
-    IO("IO"),
-
-    /**
-     * Brunei.
-     */
-    @SerializedName("BN")
-    BN("BN"),
-
-    /**
-     * Bulgaria.
-     */
-    @SerializedName("BG")
-    BG("BG"),
+    @SerializedName("BE")
+    BE("BE"),
 
     /**
      * Burkina Faso.
@@ -208,28 +130,52 @@ enum class CountryCode(val value: String) {
     BF("BF"),
 
     /**
+     * Bulgaria.
+     */
+    @SerializedName("BG")
+    BG("BG"),
+
+    /**
+     * Bahrain.
+     */
+    @SerializedName("BH")
+    BH("BH"),
+
+    /**
      * Burundi.
      */
     @SerializedName("BI")
     BI("BI"),
 
     /**
-     * Cambodia.
+     * Benin.
      */
-    @SerializedName("KH")
-    KH("KH"),
+    @SerializedName("BJ")
+    BJ("BJ"),
 
     /**
-     * Canada.
+     * Saint Barthélemy.
      */
-    @SerializedName("CA")
-    CA("CA"),
+    @SerializedName("BL")
+    BL("BL"),
 
     /**
-     * Cape Verde.
+     * Bermuda.
      */
-    @SerializedName("CV")
-    CV("CV"),
+    @SerializedName("BM")
+    BM("BM"),
+
+    /**
+     * Brunei.
+     */
+    @SerializedName("BN")
+    BN("BN"),
+
+    /**
+     * Bolivia.
+     */
+    @SerializedName("BO")
+    BO("BO"),
 
     /**
      * Caribbean Netherlands.
@@ -238,40 +184,52 @@ enum class CountryCode(val value: String) {
     BQ("BQ"),
 
     /**
-     * Cayman Islands.
+     * Brazil.
      */
-    @SerializedName("KY")
-    KY("KY"),
+    @SerializedName("BR")
+    BR("BR"),
 
     /**
-     * Central African Republic.
+     * Bahamas.
      */
-    @SerializedName("CF")
-    CF("CF"),
+    @SerializedName("BS")
+    BS("BS"),
 
     /**
-     * Chad.
+     * Bhutan.
      */
-    @SerializedName("TD")
-    TD("TD"),
+    @SerializedName("BT")
+    BT("BT"),
 
     /**
-     * Chile.
+     * Bouvet Island.
      */
-    @SerializedName("CL")
-    CL("CL"),
+    @SerializedName("BV")
+    BV("BV"),
 
     /**
-     * China.
+     * Botswana.
      */
-    @SerializedName("CN")
-    CN("CN"),
+    @SerializedName("BW")
+    BW("BW"),
 
     /**
-     * Christmas Island.
+     * Belarus.
      */
-    @SerializedName("CX")
-    CX("CX"),
+    @SerializedName("BY")
+    BY("BY"),
+
+    /**
+     * Belize.
+     */
+    @SerializedName("BZ")
+    BZ("BZ"),
+
+    /**
+     * Canada.
+     */
+    @SerializedName("CA")
+    CA("CA"),
 
     /**
      * Cocos (Keeling) Islands.
@@ -280,16 +238,16 @@ enum class CountryCode(val value: String) {
     CC("CC"),
 
     /**
-     * Colombia.
+     * Congo, The Democratic Republic Of The.
      */
-    @SerializedName("CO")
-    CO("CO"),
+    @SerializedName("CD")
+    CD("CD"),
 
     /**
-     * Comoros.
+     * Central African Republic.
      */
-    @SerializedName("KM")
-    KM("KM"),
+    @SerializedName("CF")
+    CF("CF"),
 
     /**
      * Congo.
@@ -298,10 +256,16 @@ enum class CountryCode(val value: String) {
     CG("CG"),
 
     /**
-     * Congo, The Democratic Republic Of The.
+     * Switzerland.
      */
-    @SerializedName("CD")
-    CD("CD"),
+    @SerializedName("CH")
+    CH("CH"),
+
+    /**
+     * Côte d'Ivoire.
+     */
+    @SerializedName("CI")
+    CI("CI"),
 
     /**
      * Cook Islands.
@@ -310,16 +274,34 @@ enum class CountryCode(val value: String) {
     CK("CK"),
 
     /**
+     * Chile.
+     */
+    @SerializedName("CL")
+    CL("CL"),
+
+    /**
+     * Republic of Cameroon.
+     */
+    @SerializedName("CM")
+    CM("CM"),
+
+    /**
+     * China.
+     */
+    @SerializedName("CN")
+    CN("CN"),
+
+    /**
+     * Colombia.
+     */
+    @SerializedName("CO")
+    CO("CO"),
+
+    /**
      * Costa Rica.
      */
     @SerializedName("CR")
     CR("CR"),
-
-    /**
-     * Croatia.
-     */
-    @SerializedName("HR")
-    HR("HR"),
 
     /**
      * Cuba.
@@ -328,10 +310,22 @@ enum class CountryCode(val value: String) {
     CU("CU"),
 
     /**
+     * Cape Verde.
+     */
+    @SerializedName("CV")
+    CV("CV"),
+
+    /**
      * Curaçao.
      */
     @SerializedName("CW")
     CW("CW"),
+
+    /**
+     * Christmas Island.
+     */
+    @SerializedName("CX")
+    CX("CX"),
 
     /**
      * Cyprus.
@@ -346,22 +340,22 @@ enum class CountryCode(val value: String) {
     CZ("CZ"),
 
     /**
-     * Côte d'Ivoire.
+     * Germany.
      */
-    @SerializedName("CI")
-    CI("CI"),
-
-    /**
-     * Denmark.
-     */
-    @SerializedName("DK")
-    DK("DK"),
+    @SerializedName("DE")
+    DE("DE"),
 
     /**
      * Djibouti.
      */
     @SerializedName("DJ")
     DJ("DJ"),
+
+    /**
+     * Denmark.
+     */
+    @SerializedName("DK")
+    DK("DK"),
 
     /**
      * Dominica.
@@ -376,34 +370,16 @@ enum class CountryCode(val value: String) {
     DO("DO"),
 
     /**
+     * Algeria.
+     */
+    @SerializedName("DZ")
+    DZ("DZ"),
+
+    /**
      * Ecuador.
      */
     @SerializedName("EC")
     EC("EC"),
-
-    /**
-     * Egypt.
-     */
-    @SerializedName("EG")
-    EG("EG"),
-
-    /**
-     * El Salvador.
-     */
-    @SerializedName("SV")
-    SV("SV"),
-
-    /**
-     * Equatorial Guinea.
-     */
-    @SerializedName("GQ")
-    GQ("GQ"),
-
-    /**
-     * Eritrea.
-     */
-    @SerializedName("ER")
-    ER("ER"),
 
     /**
      * Estonia.
@@ -412,16 +388,46 @@ enum class CountryCode(val value: String) {
     EE("EE"),
 
     /**
-     * Eswatini.
+     * Egypt.
      */
-    @SerializedName("SZ")
-    SZ("SZ"),
+    @SerializedName("EG")
+    EG("EG"),
+
+    /**
+     * Western Sahara.
+     */
+    @SerializedName("EH")
+    EH("EH"),
+
+    /**
+     * Eritrea.
+     */
+    @SerializedName("ER")
+    ER("ER"),
+
+    /**
+     * Spain.
+     */
+    @SerializedName("ES")
+    ES("ES"),
 
     /**
      * Ethiopia.
      */
     @SerializedName("ET")
     ET("ET"),
+
+    /**
+     * Finland.
+     */
+    @SerializedName("FI")
+    FI("FI"),
+
+    /**
+     * Fiji.
+     */
+    @SerializedName("FJ")
+    FJ("FJ"),
 
     /**
      * Falkland Islands (Malvinas).
@@ -436,40 +442,10 @@ enum class CountryCode(val value: String) {
     FO("FO"),
 
     /**
-     * Fiji.
-     */
-    @SerializedName("FJ")
-    FJ("FJ"),
-
-    /**
-     * Finland.
-     */
-    @SerializedName("FI")
-    FI("FI"),
-
-    /**
      * France.
      */
     @SerializedName("FR")
     FR("FR"),
-
-    /**
-     * French Guiana.
-     */
-    @SerializedName("GF")
-    GF("GF"),
-
-    /**
-     * French Polynesia.
-     */
-    @SerializedName("PF")
-    PF("PF"),
-
-    /**
-     * French Southern Territories.
-     */
-    @SerializedName("TF")
-    TF("TF"),
 
     /**
      * Gabon.
@@ -478,10 +454,16 @@ enum class CountryCode(val value: String) {
     GA("GA"),
 
     /**
-     * Gambia.
+     * United Kingdom.
      */
-    @SerializedName("GM")
-    GM("GM"),
+    @SerializedName("GB")
+    GB("GB"),
+
+    /**
+     * Grenada.
+     */
+    @SerializedName("GD")
+    GD("GD"),
 
     /**
      * Georgia.
@@ -490,10 +472,16 @@ enum class CountryCode(val value: String) {
     GE("GE"),
 
     /**
-     * Germany.
+     * French Guiana.
      */
-    @SerializedName("DE")
-    DE("DE"),
+    @SerializedName("GF")
+    GF("GF"),
+
+    /**
+     * Guernsey.
+     */
+    @SerializedName("GG")
+    GG("GG"),
 
     /**
      * Ghana.
@@ -508,22 +496,22 @@ enum class CountryCode(val value: String) {
     GI("GI"),
 
     /**
-     * Greece.
-     */
-    @SerializedName("GR")
-    GR("GR"),
-
-    /**
      * Greenland.
      */
     @SerializedName("GL")
     GL("GL"),
 
     /**
-     * Grenada.
+     * Gambia.
      */
-    @SerializedName("GD")
-    GD("GD"),
+    @SerializedName("GM")
+    GM("GM"),
+
+    /**
+     * Guinea.
+     */
+    @SerializedName("GN")
+    GN("GN"),
 
     /**
      * Guadeloupe.
@@ -532,22 +520,28 @@ enum class CountryCode(val value: String) {
     GP("GP"),
 
     /**
+     * Equatorial Guinea.
+     */
+    @SerializedName("GQ")
+    GQ("GQ"),
+
+    /**
+     * Greece.
+     */
+    @SerializedName("GR")
+    GR("GR"),
+
+    /**
+     * South Georgia And The South Sandwich Islands.
+     */
+    @SerializedName("GS")
+    GS("GS"),
+
+    /**
      * Guatemala.
      */
     @SerializedName("GT")
     GT("GT"),
-
-    /**
-     * Guernsey.
-     */
-    @SerializedName("GG")
-    GG("GG"),
-
-    /**
-     * Guinea.
-     */
-    @SerializedName("GN")
-    GN("GN"),
 
     /**
      * Guinea Bissau.
@@ -562,10 +556,10 @@ enum class CountryCode(val value: String) {
     GY("GY"),
 
     /**
-     * Haiti.
+     * Hong Kong.
      */
-    @SerializedName("HT")
-    HT("HT"),
+    @SerializedName("HK")
+    HK("HK"),
 
     /**
      * Heard Island And Mcdonald Islands.
@@ -574,22 +568,22 @@ enum class CountryCode(val value: String) {
     HM("HM"),
 
     /**
-     * Holy See (Vatican City State).
-     */
-    @SerializedName("VA")
-    VA("VA"),
-
-    /**
      * Honduras.
      */
     @SerializedName("HN")
     HN("HN"),
 
     /**
-     * Hong Kong.
+     * Croatia.
      */
-    @SerializedName("HK")
-    HK("HK"),
+    @SerializedName("HR")
+    HR("HR"),
+
+    /**
+     * Haiti.
+     */
+    @SerializedName("HT")
+    HT("HT"),
 
     /**
      * Hungary.
@@ -598,34 +592,10 @@ enum class CountryCode(val value: String) {
     HU("HU"),
 
     /**
-     * Iceland.
-     */
-    @SerializedName("IS")
-    IS("IS"),
-
-    /**
-     * India.
-     */
-    @SerializedName("IN")
-    IN("IN"),
-
-    /**
      * Indonesia.
      */
     @SerializedName("ID")
     ID("ID"),
-
-    /**
-     * Iran, Islamic Republic Of.
-     */
-    @SerializedName("IR")
-    IR("IR"),
-
-    /**
-     * Iraq.
-     */
-    @SerializedName("IQ")
-    IQ("IQ"),
 
     /**
      * Ireland.
@@ -634,16 +604,46 @@ enum class CountryCode(val value: String) {
     IE("IE"),
 
     /**
+     * Israel.
+     */
+    @SerializedName("IL")
+    IL("IL"),
+
+    /**
      * Isle Of Man.
      */
     @SerializedName("IM")
     IM("IM"),
 
     /**
-     * Israel.
+     * India.
      */
-    @SerializedName("IL")
-    IL("IL"),
+    @SerializedName("IN")
+    IN("IN"),
+
+    /**
+     * British Indian Ocean Territory.
+     */
+    @SerializedName("IO")
+    IO("IO"),
+
+    /**
+     * Iraq.
+     */
+    @SerializedName("IQ")
+    IQ("IQ"),
+
+    /**
+     * Iran, Islamic Republic Of.
+     */
+    @SerializedName("IR")
+    IR("IR"),
+
+    /**
+     * Iceland.
+     */
+    @SerializedName("IS")
+    IS("IS"),
 
     /**
      * Italy.
@@ -652,22 +652,16 @@ enum class CountryCode(val value: String) {
     IT("IT"),
 
     /**
-     * Jamaica.
-     */
-    @SerializedName("JM")
-    JM("JM"),
-
-    /**
-     * Japan.
-     */
-    @SerializedName("JP")
-    JP("JP"),
-
-    /**
      * Jersey.
      */
     @SerializedName("JE")
     JE("JE"),
+
+    /**
+     * Jamaica.
+     */
+    @SerializedName("JM")
+    JM("JM"),
 
     /**
      * Jordan.
@@ -676,10 +670,10 @@ enum class CountryCode(val value: String) {
     JO("JO"),
 
     /**
-     * Kazakhstan.
+     * Japan.
      */
-    @SerializedName("KZ")
-    KZ("KZ"),
+    @SerializedName("JP")
+    JP("JP"),
 
     /**
      * Kenya.
@@ -688,10 +682,34 @@ enum class CountryCode(val value: String) {
     KE("KE"),
 
     /**
+     * Kyrgyzstan.
+     */
+    @SerializedName("KG")
+    KG("KG"),
+
+    /**
+     * Cambodia.
+     */
+    @SerializedName("KH")
+    KH("KH"),
+
+    /**
      * Kiribati.
      */
     @SerializedName("KI")
     KI("KI"),
+
+    /**
+     * Comoros.
+     */
+    @SerializedName("KM")
+    KM("KM"),
+
+    /**
+     * Saint Kitts And Nevis.
+     */
+    @SerializedName("KN")
+    KN("KN"),
 
     /**
      * Korea, Democratic People's Republic Of.
@@ -700,10 +718,10 @@ enum class CountryCode(val value: String) {
     KP("KP"),
 
     /**
-     * Kosovo.
+     * South Korea.
      */
-    @SerializedName("XK")
-    XK("XK"),
+    @SerializedName("KR")
+    KR("KR"),
 
     /**
      * Kuwait.
@@ -712,10 +730,16 @@ enum class CountryCode(val value: String) {
     KW("KW"),
 
     /**
-     * Kyrgyzstan.
+     * Cayman Islands.
      */
-    @SerializedName("KG")
-    KG("KG"),
+    @SerializedName("KY")
+    KY("KY"),
+
+    /**
+     * Kazakhstan.
+     */
+    @SerializedName("KZ")
+    KZ("KZ"),
 
     /**
      * Lao People's Democratic Republic.
@@ -724,22 +748,28 @@ enum class CountryCode(val value: String) {
     LA("LA"),
 
     /**
-     * Latvia.
-     */
-    @SerializedName("LV")
-    LV("LV"),
-
-    /**
      * Lebanon.
      */
     @SerializedName("LB")
     LB("LB"),
 
     /**
-     * Lesotho.
+     * Saint Lucia.
      */
-    @SerializedName("LS")
-    LS("LS"),
+    @SerializedName("LC")
+    LC("LC"),
+
+    /**
+     * Liechtenstein.
+     */
+    @SerializedName("LI")
+    LI("LI"),
+
+    /**
+     * Sri Lanka.
+     */
+    @SerializedName("LK")
+    LK("LK"),
 
     /**
      * Liberia.
@@ -748,16 +778,10 @@ enum class CountryCode(val value: String) {
     LR("LR"),
 
     /**
-     * Libyan Arab Jamahiriya.
+     * Lesotho.
      */
-    @SerializedName("LY")
-    LY("LY"),
-
-    /**
-     * Liechtenstein.
-     */
-    @SerializedName("LI")
-    LI("LI"),
+    @SerializedName("LS")
+    LS("LS"),
 
     /**
      * Lithuania.
@@ -772,10 +796,46 @@ enum class CountryCode(val value: String) {
     LU("LU"),
 
     /**
-     * Macao.
+     * Latvia.
      */
-    @SerializedName("MO")
-    MO("MO"),
+    @SerializedName("LV")
+    LV("LV"),
+
+    /**
+     * Libyan Arab Jamahiriya.
+     */
+    @SerializedName("LY")
+    LY("LY"),
+
+    /**
+     * Morocco.
+     */
+    @SerializedName("MA")
+    MA("MA"),
+
+    /**
+     * Monaco.
+     */
+    @SerializedName("MC")
+    MC("MC"),
+
+    /**
+     * Moldova, Republic of.
+     */
+    @SerializedName("MD")
+    MD("MD"),
+
+    /**
+     * Montenegro.
+     */
+    @SerializedName("ME")
+    ME("ME"),
+
+    /**
+     * Saint Martin.
+     */
+    @SerializedName("MF")
+    MF("MF"),
 
     /**
      * Madagascar.
@@ -784,22 +844,10 @@ enum class CountryCode(val value: String) {
     MG("MG"),
 
     /**
-     * Malawi.
+     * North Macedonia.
      */
-    @SerializedName("MW")
-    MW("MW"),
-
-    /**
-     * Malaysia.
-     */
-    @SerializedName("MY")
-    MY("MY"),
-
-    /**
-     * Maldives.
-     */
-    @SerializedName("MV")
-    MV("MV"),
+    @SerializedName("MK")
+    MK("MK"),
 
     /**
      * Mali.
@@ -808,10 +856,22 @@ enum class CountryCode(val value: String) {
     ML("ML"),
 
     /**
-     * Malta.
+     * Myanmar.
      */
-    @SerializedName("MT")
-    MT("MT"),
+    @SerializedName("MM")
+    MM("MM"),
+
+    /**
+     * Mongolia.
+     */
+    @SerializedName("MN")
+    MN("MN"),
+
+    /**
+     * Macao.
+     */
+    @SerializedName("MO")
+    MO("MO"),
 
     /**
      * Martinique.
@@ -826,16 +886,34 @@ enum class CountryCode(val value: String) {
     MR("MR"),
 
     /**
+     * Montserrat.
+     */
+    @SerializedName("MS")
+    MS("MS"),
+
+    /**
+     * Malta.
+     */
+    @SerializedName("MT")
+    MT("MT"),
+
+    /**
      * Mauritius.
      */
     @SerializedName("MU")
     MU("MU"),
 
     /**
-     * Mayotte.
+     * Maldives.
      */
-    @SerializedName("YT")
-    YT("YT"),
+    @SerializedName("MV")
+    MV("MV"),
+
+    /**
+     * Malawi.
+     */
+    @SerializedName("MW")
+    MW("MW"),
 
     /**
      * Mexico.
@@ -844,40 +922,10 @@ enum class CountryCode(val value: String) {
     MX("MX"),
 
     /**
-     * Moldova, Republic of.
+     * Malaysia.
      */
-    @SerializedName("MD")
-    MD("MD"),
-
-    /**
-     * Monaco.
-     */
-    @SerializedName("MC")
-    MC("MC"),
-
-    /**
-     * Mongolia.
-     */
-    @SerializedName("MN")
-    MN("MN"),
-
-    /**
-     * Montenegro.
-     */
-    @SerializedName("ME")
-    ME("ME"),
-
-    /**
-     * Montserrat.
-     */
-    @SerializedName("MS")
-    MS("MS"),
-
-    /**
-     * Morocco.
-     */
-    @SerializedName("MA")
-    MA("MA"),
+    @SerializedName("MY")
+    MY("MY"),
 
     /**
      * Mozambique.
@@ -886,40 +934,10 @@ enum class CountryCode(val value: String) {
     MZ("MZ"),
 
     /**
-     * Myanmar.
-     */
-    @SerializedName("MM")
-    MM("MM"),
-
-    /**
      * Namibia.
      */
     @SerializedName("NA")
     NA("NA"),
-
-    /**
-     * Nauru.
-     */
-    @SerializedName("NR")
-    NR("NR"),
-
-    /**
-     * Nepal.
-     */
-    @SerializedName("NP")
-    NP("NP"),
-
-    /**
-     * Netherlands.
-     */
-    @SerializedName("NL")
-    NL("NL"),
-
-    /**
-     * Netherlands Antilles.
-     */
-    @SerializedName("AN")
-    AN("AN"),
 
     /**
      * New Caledonia.
@@ -928,34 +946,10 @@ enum class CountryCode(val value: String) {
     NC("NC"),
 
     /**
-     * New Zealand.
-     */
-    @SerializedName("NZ")
-    NZ("NZ"),
-
-    /**
-     * Nicaragua.
-     */
-    @SerializedName("NI")
-    NI("NI"),
-
-    /**
      * Niger.
      */
     @SerializedName("NE")
     NE("NE"),
-
-    /**
-     * Nigeria.
-     */
-    @SerializedName("NG")
-    NG("NG"),
-
-    /**
-     * Niue.
-     */
-    @SerializedName("NU")
-    NU("NU"),
 
     /**
      * Norfolk Island.
@@ -964,10 +958,22 @@ enum class CountryCode(val value: String) {
     NF("NF"),
 
     /**
-     * North Macedonia.
+     * Nigeria.
      */
-    @SerializedName("MK")
-    MK("MK"),
+    @SerializedName("NG")
+    NG("NG"),
+
+    /**
+     * Nicaragua.
+     */
+    @SerializedName("NI")
+    NI("NI"),
+
+    /**
+     * Netherlands.
+     */
+    @SerializedName("NL")
+    NL("NL"),
 
     /**
      * Norway.
@@ -976,22 +982,34 @@ enum class CountryCode(val value: String) {
     NO("NO"),
 
     /**
+     * Nepal.
+     */
+    @SerializedName("NP")
+    NP("NP"),
+
+    /**
+     * Nauru.
+     */
+    @SerializedName("NR")
+    NR("NR"),
+
+    /**
+     * Niue.
+     */
+    @SerializedName("NU")
+    NU("NU"),
+
+    /**
+     * New Zealand.
+     */
+    @SerializedName("NZ")
+    NZ("NZ"),
+
+    /**
      * Oman.
      */
     @SerializedName("OM")
     OM("OM"),
-
-    /**
-     * Pakistan.
-     */
-    @SerializedName("PK")
-    PK("PK"),
-
-    /**
-     * Palestinian Territory, Occupied.
-     */
-    @SerializedName("PS")
-    PS("PS"),
 
     /**
      * Panama.
@@ -1000,22 +1018,22 @@ enum class CountryCode(val value: String) {
     PA("PA"),
 
     /**
-     * Papua New Guinea.
-     */
-    @SerializedName("PG")
-    PG("PG"),
-
-    /**
-     * Paraguay.
-     */
-    @SerializedName("PY")
-    PY("PY"),
-
-    /**
      * Peru.
      */
     @SerializedName("PE")
     PE("PE"),
+
+    /**
+     * French Polynesia.
+     */
+    @SerializedName("PF")
+    PF("PF"),
+
+    /**
+     * Papua New Guinea.
+     */
+    @SerializedName("PG")
+    PG("PG"),
 
     /**
      * Philippines.
@@ -1024,10 +1042,10 @@ enum class CountryCode(val value: String) {
     PH("PH"),
 
     /**
-     * Pitcairn.
+     * Pakistan.
      */
-    @SerializedName("PN")
-    PN("PN"),
+    @SerializedName("PK")
+    PK("PK"),
 
     /**
      * Poland.
@@ -1036,22 +1054,40 @@ enum class CountryCode(val value: String) {
     PL("PL"),
 
     /**
+     * Saint Pierre And Miquelon.
+     */
+    @SerializedName("PM")
+    PM("PM"),
+
+    /**
+     * Pitcairn.
+     */
+    @SerializedName("PN")
+    PN("PN"),
+
+    /**
+     * Palestinian Territory, Occupied.
+     */
+    @SerializedName("PS")
+    PS("PS"),
+
+    /**
      * Portugal.
      */
     @SerializedName("PT")
     PT("PT"),
 
     /**
+     * Paraguay.
+     */
+    @SerializedName("PY")
+    PY("PY"),
+
+    /**
      * Qatar.
      */
     @SerializedName("QA")
     QA("QA"),
-
-    /**
-     * Republic of Cameroon.
-     */
-    @SerializedName("CM")
-    CM("CM"),
 
     /**
      * Reunion.
@@ -1066,6 +1102,12 @@ enum class CountryCode(val value: String) {
     RO("RO"),
 
     /**
+     * Serbia.
+     */
+    @SerializedName("RS")
+    RS("RS"),
+
+    /**
      * Russia.
      */
     @SerializedName("RU")
@@ -1078,112 +1120,10 @@ enum class CountryCode(val value: String) {
     RW("RW"),
 
     /**
-     * Saint Barthélemy.
-     */
-    @SerializedName("BL")
-    BL("BL"),
-
-    /**
-     * Saint Helena.
-     */
-    @SerializedName("SH")
-    SH("SH"),
-
-    /**
-     * Saint Kitts And Nevis.
-     */
-    @SerializedName("KN")
-    KN("KN"),
-
-    /**
-     * Saint Lucia.
-     */
-    @SerializedName("LC")
-    LC("LC"),
-
-    /**
-     * Saint Martin.
-     */
-    @SerializedName("MF")
-    MF("MF"),
-
-    /**
-     * Saint Pierre And Miquelon.
-     */
-    @SerializedName("PM")
-    PM("PM"),
-
-    /**
-     * Samoa.
-     */
-    @SerializedName("WS")
-    WS("WS"),
-
-    /**
-     * San Marino.
-     */
-    @SerializedName("SM")
-    SM("SM"),
-
-    /**
-     * Sao Tome And Principe.
-     */
-    @SerializedName("ST")
-    ST("ST"),
-
-    /**
      * Saudi Arabia.
      */
     @SerializedName("SA")
     SA("SA"),
-
-    /**
-     * Senegal.
-     */
-    @SerializedName("SN")
-    SN("SN"),
-
-    /**
-     * Serbia.
-     */
-    @SerializedName("RS")
-    RS("RS"),
-
-    /**
-     * Seychelles.
-     */
-    @SerializedName("SC")
-    SC("SC"),
-
-    /**
-     * Sierra Leone.
-     */
-    @SerializedName("SL")
-    SL("SL"),
-
-    /**
-     * Singapore.
-     */
-    @SerializedName("SG")
-    SG("SG"),
-
-    /**
-     * Sint Maarten.
-     */
-    @SerializedName("SX")
-    SX("SX"),
-
-    /**
-     * Slovakia.
-     */
-    @SerializedName("SK")
-    SK("SK"),
-
-    /**
-     * Slovenia.
-     */
-    @SerializedName("SI")
-    SI("SI"),
 
     /**
      * Solomon Islands.
@@ -1192,52 +1132,10 @@ enum class CountryCode(val value: String) {
     SB("SB"),
 
     /**
-     * Somalia.
+     * Seychelles.
      */
-    @SerializedName("SO")
-    SO("SO"),
-
-    /**
-     * South Africa.
-     */
-    @SerializedName("ZA")
-    ZA("ZA"),
-
-    /**
-     * South Georgia And The South Sandwich Islands.
-     */
-    @SerializedName("GS")
-    GS("GS"),
-
-    /**
-     * South Korea.
-     */
-    @SerializedName("KR")
-    KR("KR"),
-
-    /**
-     * South Sudan.
-     */
-    @SerializedName("SS")
-    SS("SS"),
-
-    /**
-     * Spain.
-     */
-    @SerializedName("ES")
-    ES("ES"),
-
-    /**
-     * Sri Lanka.
-     */
-    @SerializedName("LK")
-    LK("LK"),
-
-    /**
-     * St. Vincent.
-     */
-    @SerializedName("VC")
-    VC("VC"),
+    @SerializedName("SC")
+    SC("SC"),
 
     /**
      * Sudan.
@@ -1246,10 +1144,28 @@ enum class CountryCode(val value: String) {
     SD("SD"),
 
     /**
-     * Suriname.
+     * Sweden.
      */
-    @SerializedName("SR")
-    SR("SR"),
+    @SerializedName("SE")
+    SE("SE"),
+
+    /**
+     * Singapore.
+     */
+    @SerializedName("SG")
+    SG("SG"),
+
+    /**
+     * Saint Helena.
+     */
+    @SerializedName("SH")
+    SH("SH"),
+
+    /**
+     * Slovenia.
+     */
+    @SerializedName("SI")
+    SI("SI"),
 
     /**
      * Svalbard And Jan Mayen.
@@ -1258,16 +1174,64 @@ enum class CountryCode(val value: String) {
     SJ("SJ"),
 
     /**
-     * Sweden.
+     * Slovakia.
      */
-    @SerializedName("SE")
-    SE("SE"),
+    @SerializedName("SK")
+    SK("SK"),
 
     /**
-     * Switzerland.
+     * Sierra Leone.
      */
-    @SerializedName("CH")
-    CH("CH"),
+    @SerializedName("SL")
+    SL("SL"),
+
+    /**
+     * San Marino.
+     */
+    @SerializedName("SM")
+    SM("SM"),
+
+    /**
+     * Senegal.
+     */
+    @SerializedName("SN")
+    SN("SN"),
+
+    /**
+     * Somalia.
+     */
+    @SerializedName("SO")
+    SO("SO"),
+
+    /**
+     * Suriname.
+     */
+    @SerializedName("SR")
+    SR("SR"),
+
+    /**
+     * South Sudan.
+     */
+    @SerializedName("SS")
+    SS("SS"),
+
+    /**
+     * Sao Tome And Principe.
+     */
+    @SerializedName("ST")
+    ST("ST"),
+
+    /**
+     * El Salvador.
+     */
+    @SerializedName("SV")
+    SV("SV"),
+
+    /**
+     * Sint Maarten.
+     */
+    @SerializedName("SX")
+    SX("SX"),
 
     /**
      * Syria.
@@ -1276,76 +1240,10 @@ enum class CountryCode(val value: String) {
     SY("SY"),
 
     /**
-     * Taiwan.
+     * Eswatini.
      */
-    @SerializedName("TW")
-    TW("TW"),
-
-    /**
-     * Tajikistan.
-     */
-    @SerializedName("TJ")
-    TJ("TJ"),
-
-    /**
-     * Tanzania, United Republic Of.
-     */
-    @SerializedName("TZ")
-    TZ("TZ"),
-
-    /**
-     * Thailand.
-     */
-    @SerializedName("TH")
-    TH("TH"),
-
-    /**
-     * Timor Leste.
-     */
-    @SerializedName("TL")
-    TL("TL"),
-
-    /**
-     * Togo.
-     */
-    @SerializedName("TG")
-    TG("TG"),
-
-    /**
-     * Tokelau.
-     */
-    @SerializedName("TK")
-    TK("TK"),
-
-    /**
-     * Tonga.
-     */
-    @SerializedName("TO")
-    TO("TO"),
-
-    /**
-     * Trinidad and Tobago.
-     */
-    @SerializedName("TT")
-    TT("TT"),
-
-    /**
-     * Tunisia.
-     */
-    @SerializedName("TN")
-    TN("TN"),
-
-    /**
-     * Turkey.
-     */
-    @SerializedName("TR")
-    TR("TR"),
-
-    /**
-     * Turkmenistan.
-     */
-    @SerializedName("TM")
-    TM("TM"),
+    @SerializedName("SZ")
+    SZ("SZ"),
 
     /**
      * Turks and Caicos Islands.
@@ -1354,16 +1252,94 @@ enum class CountryCode(val value: String) {
     TC("TC"),
 
     /**
+     * Chad.
+     */
+    @SerializedName("TD")
+    TD("TD"),
+
+    /**
+     * French Southern Territories.
+     */
+    @SerializedName("TF")
+    TF("TF"),
+
+    /**
+     * Togo.
+     */
+    @SerializedName("TG")
+    TG("TG"),
+
+    /**
+     * Thailand.
+     */
+    @SerializedName("TH")
+    TH("TH"),
+
+    /**
+     * Tajikistan.
+     */
+    @SerializedName("TJ")
+    TJ("TJ"),
+
+    /**
+     * Tokelau.
+     */
+    @SerializedName("TK")
+    TK("TK"),
+
+    /**
+     * Timor Leste.
+     */
+    @SerializedName("TL")
+    TL("TL"),
+
+    /**
+     * Turkmenistan.
+     */
+    @SerializedName("TM")
+    TM("TM"),
+
+    /**
+     * Tunisia.
+     */
+    @SerializedName("TN")
+    TN("TN"),
+
+    /**
+     * Tonga.
+     */
+    @SerializedName("TO")
+    TO("TO"),
+
+    /**
+     * Turkey.
+     */
+    @SerializedName("TR")
+    TR("TR"),
+
+    /**
+     * Trinidad and Tobago.
+     */
+    @SerializedName("TT")
+    TT("TT"),
+
+    /**
      * Tuvalu.
      */
     @SerializedName("TV")
     TV("TV"),
 
     /**
-     * Uganda.
+     * Taiwan.
      */
-    @SerializedName("UG")
-    UG("UG"),
+    @SerializedName("TW")
+    TW("TW"),
+
+    /**
+     * Tanzania, United Republic Of.
+     */
+    @SerializedName("TZ")
+    TZ("TZ"),
 
     /**
      * Ukraine.
@@ -1372,28 +1348,22 @@ enum class CountryCode(val value: String) {
     UA("UA"),
 
     /**
-     * United Arab Emirates.
+     * Uganda.
      */
-    @SerializedName("AE")
-    AE("AE"),
-
-    /**
-     * United Kingdom.
-     */
-    @SerializedName("GB")
-    GB("GB"),
-
-    /**
-     * United States.
-     */
-    @SerializedName("US")
-    US("US"),
+    @SerializedName("UG")
+    UG("UG"),
 
     /**
      * United States Minor Outlying Islands.
      */
     @SerializedName("UM")
     UM("UM"),
+
+    /**
+     * United States.
+     */
+    @SerializedName("US")
+    US("US"),
 
     /**
      * Uruguay.
@@ -1408,10 +1378,16 @@ enum class CountryCode(val value: String) {
     UZ("UZ"),
 
     /**
-     * Vanuatu.
+     * Holy See (Vatican City State).
      */
-    @SerializedName("VU")
-    VU("VU"),
+    @SerializedName("VA")
+    VA("VA"),
+
+    /**
+     * St. Vincent.
+     */
+    @SerializedName("VC")
+    VC("VC"),
 
     /**
      * Venezuela.
@@ -1420,16 +1396,22 @@ enum class CountryCode(val value: String) {
     VE("VE"),
 
     /**
+     * Virgin Islands, British.
+     */
+    @SerializedName("VG")
+    VG("VG"),
+
+    /**
      * Vietnam.
      */
     @SerializedName("VN")
     VN("VN"),
 
     /**
-     * Virgin Islands, British.
+     * Vanuatu.
      */
-    @SerializedName("VG")
-    VG("VG"),
+    @SerializedName("VU")
+    VU("VU"),
 
     /**
      * Wallis And Futuna.
@@ -1438,16 +1420,34 @@ enum class CountryCode(val value: String) {
     WF("WF"),
 
     /**
-     * Western Sahara.
+     * Samoa.
      */
-    @SerializedName("EH")
-    EH("EH"),
+    @SerializedName("WS")
+    WS("WS"),
+
+    /**
+     * Kosovo.
+     */
+    @SerializedName("XK")
+    XK("XK"),
 
     /**
      * Yemen.
      */
     @SerializedName("YE")
     YE("YE"),
+
+    /**
+     * Mayotte.
+     */
+    @SerializedName("YT")
+    YT("YT"),
+
+    /**
+     * South Africa.
+     */
+    @SerializedName("ZA")
+    ZA("ZA"),
 
     /**
      * Zambia.

--- a/Tests/Resources/ExpectedKotlinCode/Enums/CurrencyCode.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/CurrencyCode.kt
@@ -10,28 +10,10 @@ import javax.annotation.Generated
 enum class CurrencyCode(val value: String) {
 
     /**
-     * United States Dollars (USD).
+     * United Arab Emirates Dirham (AED).
      */
-    @SerializedName("USD")
-    USD("USD"),
-
-    /**
-     * Euro (EUR).
-     */
-    @SerializedName("EUR")
-    EUR("EUR"),
-
-    /**
-     * United Kingdom Pounds (GBP).
-     */
-    @SerializedName("GBP")
-    GBP("GBP"),
-
-    /**
-     * Canadian Dollars (CAD).
-     */
-    @SerializedName("CAD")
-    CAD("CAD"),
+    @SerializedName("AED")
+    AED("AED"),
 
     /**
      * Afghan Afghani (AFN).
@@ -46,10 +28,16 @@ enum class CurrencyCode(val value: String) {
     ALL("ALL"),
 
     /**
-     * Algerian Dinar (DZD).
+     * Armenian Dram (AMD).
      */
-    @SerializedName("DZD")
-    DZD("DZD"),
+    @SerializedName("AMD")
+    AMD("AMD"),
+
+    /**
+     * Netherlands Antillean Guilder.
+     */
+    @SerializedName("ANG")
+    ANG("ANG"),
 
     /**
      * Angolan Kwanza (AOA).
@@ -64,10 +52,10 @@ enum class CurrencyCode(val value: String) {
     ARS("ARS"),
 
     /**
-     * Armenian Dram (AMD).
+     * Australian Dollars (AUD).
      */
-    @SerializedName("AMD")
-    AMD("AMD"),
+    @SerializedName("AUD")
+    AUD("AUD"),
 
     /**
      * Aruban Florin (AWG).
@@ -76,10 +64,16 @@ enum class CurrencyCode(val value: String) {
     AWG("AWG"),
 
     /**
-     * Australian Dollars (AUD).
+     * Azerbaijani Manat (AZN).
      */
-    @SerializedName("AUD")
-    AUD("AUD"),
+    @SerializedName("AZN")
+    AZN("AZN"),
+
+    /**
+     * Bosnia and Herzegovina Convertible Mark (BAM).
+     */
+    @SerializedName("BAM")
+    BAM("BAM"),
 
     /**
      * Barbadian Dollar (BBD).
@@ -88,22 +82,16 @@ enum class CurrencyCode(val value: String) {
     BBD("BBD"),
 
     /**
-     * Azerbaijani Manat (AZN).
-     */
-    @SerializedName("AZN")
-    AZN("AZN"),
-
-    /**
      * Bangladesh Taka (BDT).
      */
     @SerializedName("BDT")
     BDT("BDT"),
 
     /**
-     * Bahamian Dollar (BSD).
+     * Bulgarian Lev (BGN).
      */
-    @SerializedName("BSD")
-    BSD("BSD"),
+    @SerializedName("BGN")
+    BGN("BGN"),
 
     /**
      * Bahraini Dinar (BHD).
@@ -116,6 +104,48 @@ enum class CurrencyCode(val value: String) {
      */
     @SerializedName("BIF")
     BIF("BIF"),
+
+    /**
+     * Bermudian Dollar (BMD).
+     */
+    @SerializedName("BMD")
+    BMD("BMD"),
+
+    /**
+     * Brunei Dollar (BND).
+     */
+    @SerializedName("BND")
+    BND("BND"),
+
+    /**
+     * Bolivian Boliviano (BOB).
+     */
+    @SerializedName("BOB")
+    BOB("BOB"),
+
+    /**
+     * Brazilian Real (BRL).
+     */
+    @SerializedName("BRL")
+    BRL("BRL"),
+
+    /**
+     * Bahamian Dollar (BSD).
+     */
+    @SerializedName("BSD")
+    BSD("BSD"),
+
+    /**
+     * Bhutanese Ngultrum (BTN).
+     */
+    @SerializedName("BTN")
+    BTN("BTN"),
+
+    /**
+     * Botswana Pula (BWP).
+     */
+    @SerializedName("BWP")
+    BWP("BWP"),
 
     /**
      * Belarusian Ruble (BYN).
@@ -137,82 +167,22 @@ enum class CurrencyCode(val value: String) {
     BZD("BZD"),
 
     /**
-     * Bermudian Dollar (BMD).
+     * Canadian Dollars (CAD).
      */
-    @SerializedName("BMD")
-    BMD("BMD"),
+    @SerializedName("CAD")
+    CAD("CAD"),
 
     /**
-     * Bhutanese Ngultrum (BTN).
+     * Congolese franc (CDF).
      */
-    @SerializedName("BTN")
-    BTN("BTN"),
+    @SerializedName("CDF")
+    CDF("CDF"),
 
     /**
-     * Bosnia and Herzegovina Convertible Mark (BAM).
+     * Swiss Francs (CHF).
      */
-    @SerializedName("BAM")
-    BAM("BAM"),
-
-    /**
-     * Brazilian Real (BRL).
-     */
-    @SerializedName("BRL")
-    BRL("BRL"),
-
-    /**
-     * Bolivian Boliviano (BOB).
-     */
-    @SerializedName("BOB")
-    BOB("BOB"),
-
-    /**
-     * Botswana Pula (BWP).
-     */
-    @SerializedName("BWP")
-    BWP("BWP"),
-
-    /**
-     * Brunei Dollar (BND).
-     */
-    @SerializedName("BND")
-    BND("BND"),
-
-    /**
-     * Bulgarian Lev (BGN).
-     */
-    @SerializedName("BGN")
-    BGN("BGN"),
-
-    /**
-     * Burmese Kyat (MMK).
-     */
-    @SerializedName("MMK")
-    MMK("MMK"),
-
-    /**
-     * Cambodian Riel.
-     */
-    @SerializedName("KHR")
-    KHR("KHR"),
-
-    /**
-     * Cape Verdean escudo (CVE).
-     */
-    @SerializedName("CVE")
-    CVE("CVE"),
-
-    /**
-     * Cayman Dollars (KYD).
-     */
-    @SerializedName("KYD")
-    KYD("KYD"),
-
-    /**
-     * Central African CFA Franc (XAF).
-     */
-    @SerializedName("XAF")
-    XAF("XAF"),
+    @SerializedName("CHF")
+    CHF("CHF"),
 
     /**
      * Chilean Peso (CLP).
@@ -233,28 +203,16 @@ enum class CurrencyCode(val value: String) {
     COP("COP"),
 
     /**
-     * Comorian Franc (KMF).
-     */
-    @SerializedName("KMF")
-    KMF("KMF"),
-
-    /**
-     * Congolese franc (CDF).
-     */
-    @SerializedName("CDF")
-    CDF("CDF"),
-
-    /**
      * Costa Rican Colones (CRC).
      */
     @SerializedName("CRC")
     CRC("CRC"),
 
     /**
-     * Croatian Kuna (HRK).
+     * Cape Verdean escudo (CVE).
      */
-    @SerializedName("HRK")
-    HRK("HRK"),
+    @SerializedName("CVE")
+    CVE("CVE"),
 
     /**
      * Czech Koruny (CZK).
@@ -263,16 +221,16 @@ enum class CurrencyCode(val value: String) {
     CZK("CZK"),
 
     /**
-     * Danish Kroner (DKK).
-     */
-    @SerializedName("DKK")
-    DKK("DKK"),
-
-    /**
      * Djiboutian Franc (DJF).
      */
     @SerializedName("DJF")
     DJF("DJF"),
+
+    /**
+     * Danish Kroner (DKK).
+     */
+    @SerializedName("DKK")
+    DKK("DKK"),
 
     /**
      * Dominican Peso (DOP).
@@ -281,10 +239,10 @@ enum class CurrencyCode(val value: String) {
     DOP("DOP"),
 
     /**
-     * East Caribbean Dollar (XCD).
+     * Algerian Dinar (DZD).
      */
-    @SerializedName("XCD")
-    XCD("XCD"),
+    @SerializedName("DZD")
+    DZD("DZD"),
 
     /**
      * Egyptian Pound (EGP).
@@ -299,22 +257,40 @@ enum class CurrencyCode(val value: String) {
     ETB("ETB"),
 
     /**
-     * Falkland Islands Pounds (FKP).
+     * Euro (EUR).
      */
-    @SerializedName("FKP")
-    FKP("FKP"),
-
-    /**
-     * CFP Franc (XPF).
-     */
-    @SerializedName("XPF")
-    XPF("XPF"),
+    @SerializedName("EUR")
+    EUR("EUR"),
 
     /**
      * Fijian Dollars (FJD).
      */
     @SerializedName("FJD")
     FJD("FJD"),
+
+    /**
+     * Falkland Islands Pounds (FKP).
+     */
+    @SerializedName("FKP")
+    FKP("FKP"),
+
+    /**
+     * United Kingdom Pounds (GBP).
+     */
+    @SerializedName("GBP")
+    GBP("GBP"),
+
+    /**
+     * Georgian Lari (GEL).
+     */
+    @SerializedName("GEL")
+    GEL("GEL"),
+
+    /**
+     * Ghanaian Cedi (GHS).
+     */
+    @SerializedName("GHS")
+    GHS("GHS"),
 
     /**
      * Gibraltar Pounds (GIP).
@@ -329,10 +305,10 @@ enum class CurrencyCode(val value: String) {
     GMD("GMD"),
 
     /**
-     * Ghanaian Cedi (GHS).
+     * Guinean Franc (GNF).
      */
-    @SerializedName("GHS")
-    GHS("GHS"),
+    @SerializedName("GNF")
+    GNF("GNF"),
 
     /**
      * Guatemalan Quetzal (GTQ).
@@ -347,22 +323,10 @@ enum class CurrencyCode(val value: String) {
     GYD("GYD"),
 
     /**
-     * Georgian Lari (GEL).
+     * Hong Kong Dollars (HKD).
      */
-    @SerializedName("GEL")
-    GEL("GEL"),
-
-    /**
-     * Guinean Franc (GNF).
-     */
-    @SerializedName("GNF")
-    GNF("GNF"),
-
-    /**
-     * Haitian Gourde (HTG).
-     */
-    @SerializedName("HTG")
-    HTG("HTG"),
+    @SerializedName("HKD")
+    HKD("HKD"),
 
     /**
      * Honduran Lempira (HNL).
@@ -371,28 +335,22 @@ enum class CurrencyCode(val value: String) {
     HNL("HNL"),
 
     /**
-     * Hong Kong Dollars (HKD).
+     * Croatian Kuna (HRK).
      */
-    @SerializedName("HKD")
-    HKD("HKD"),
+    @SerializedName("HRK")
+    HRK("HRK"),
+
+    /**
+     * Haitian Gourde (HTG).
+     */
+    @SerializedName("HTG")
+    HTG("HTG"),
 
     /**
      * Hungarian Forint (HUF).
      */
     @SerializedName("HUF")
     HUF("HUF"),
-
-    /**
-     * Icelandic Kronur (ISK).
-     */
-    @SerializedName("ISK")
-    ISK("ISK"),
-
-    /**
-     * Indian Rupees (INR).
-     */
-    @SerializedName("INR")
-    INR("INR"),
 
     /**
      * Indonesian Rupiah (IDR).
@@ -407,10 +365,10 @@ enum class CurrencyCode(val value: String) {
     ILS("ILS"),
 
     /**
-     * Iranian Rial (IRR).
+     * Indian Rupees (INR).
      */
-    @SerializedName("IRR")
-    IRR("IRR"),
+    @SerializedName("INR")
+    INR("INR"),
 
     /**
      * Iraqi Dinar (IQD).
@@ -419,16 +377,16 @@ enum class CurrencyCode(val value: String) {
     IQD("IQD"),
 
     /**
-     * Jamaican Dollars (JMD).
+     * Iranian Rial (IRR).
      */
-    @SerializedName("JMD")
-    JMD("JMD"),
+    @SerializedName("IRR")
+    IRR("IRR"),
 
     /**
-     * Japanese Yen (JPY).
+     * Icelandic Kronur (ISK).
      */
-    @SerializedName("JPY")
-    JPY("JPY"),
+    @SerializedName("ISK")
+    ISK("ISK"),
 
     /**
      * Jersey Pound.
@@ -437,16 +395,22 @@ enum class CurrencyCode(val value: String) {
     JEP("JEP"),
 
     /**
+     * Jamaican Dollars (JMD).
+     */
+    @SerializedName("JMD")
+    JMD("JMD"),
+
+    /**
      * Jordanian Dinar (JOD).
      */
     @SerializedName("JOD")
     JOD("JOD"),
 
     /**
-     * Kazakhstani Tenge (KZT).
+     * Japanese Yen (JPY).
      */
-    @SerializedName("KZT")
-    KZT("KZT"),
+    @SerializedName("JPY")
+    JPY("JPY"),
 
     /**
      * Kenyan Shilling (KES).
@@ -455,16 +419,46 @@ enum class CurrencyCode(val value: String) {
     KES("KES"),
 
     /**
+     * Kyrgyzstani Som (KGS).
+     */
+    @SerializedName("KGS")
+    KGS("KGS"),
+
+    /**
+     * Cambodian Riel.
+     */
+    @SerializedName("KHR")
+    KHR("KHR"),
+
+    /**
+     * Comorian Franc (KMF).
+     */
+    @SerializedName("KMF")
+    KMF("KMF"),
+
+    /**
+     * South Korean Won (KRW).
+     */
+    @SerializedName("KRW")
+    KRW("KRW"),
+
+    /**
      * Kuwaiti Dinar (KWD).
      */
     @SerializedName("KWD")
     KWD("KWD"),
 
     /**
-     * Kyrgyzstani Som (KGS).
+     * Cayman Dollars (KYD).
      */
-    @SerializedName("KGS")
-    KGS("KGS"),
+    @SerializedName("KYD")
+    KYD("KYD"),
+
+    /**
+     * Kazakhstani Tenge (KZT).
+     */
+    @SerializedName("KZT")
+    KZT("KZT"),
 
     /**
      * Laotian Kip (LAK).
@@ -473,22 +467,16 @@ enum class CurrencyCode(val value: String) {
     LAK("LAK"),
 
     /**
-     * Latvian Lati (LVL).
-     */
-    @SerializedName("LVL")
-    LVL("LVL"),
-
-    /**
      * Lebanese Pounds (LBP).
      */
     @SerializedName("LBP")
     LBP("LBP"),
 
     /**
-     * Lesotho Loti (LSL).
+     * Sri Lankan Rupees (LKR).
      */
-    @SerializedName("LSL")
-    LSL("LSL"),
+    @SerializedName("LKR")
+    LKR("LKR"),
 
     /**
      * Liberian Dollar (LRD).
@@ -497,16 +485,40 @@ enum class CurrencyCode(val value: String) {
     LRD("LRD"),
 
     /**
-     * Libyan Dinar (LYD).
+     * Lesotho Loti (LSL).
      */
-    @SerializedName("LYD")
-    LYD("LYD"),
+    @SerializedName("LSL")
+    LSL("LSL"),
 
     /**
      * Lithuanian Litai (LTL).
      */
     @SerializedName("LTL")
     LTL("LTL"),
+
+    /**
+     * Latvian Lati (LVL).
+     */
+    @SerializedName("LVL")
+    LVL("LVL"),
+
+    /**
+     * Libyan Dinar (LYD).
+     */
+    @SerializedName("LYD")
+    LYD("LYD"),
+
+    /**
+     * Moroccan Dirham.
+     */
+    @SerializedName("MAD")
+    MAD("MAD"),
+
+    /**
+     * Moldovan Leu (MDL).
+     */
+    @SerializedName("MDL")
+    MDL("MDL"),
 
     /**
      * Malagasy Ariary (MGA).
@@ -521,22 +533,40 @@ enum class CurrencyCode(val value: String) {
     MKD("MKD"),
 
     /**
+     * Burmese Kyat (MMK).
+     */
+    @SerializedName("MMK")
+    MMK("MMK"),
+
+    /**
+     * Mongolian Tugrik.
+     */
+    @SerializedName("MNT")
+    MNT("MNT"),
+
+    /**
      * Macanese Pataca (MOP).
      */
     @SerializedName("MOP")
     MOP("MOP"),
 
     /**
-     * Malawian Kwacha (MWK).
+     * Mauritian Rupee (MUR).
      */
-    @SerializedName("MWK")
-    MWK("MWK"),
+    @SerializedName("MUR")
+    MUR("MUR"),
 
     /**
      * Maldivian Rufiyaa (MVR).
      */
     @SerializedName("MVR")
     MVR("MVR"),
+
+    /**
+     * Malawian Kwacha (MWK).
+     */
+    @SerializedName("MWK")
+    MWK("MWK"),
 
     /**
      * Mexican Pesos (MXN).
@@ -551,30 +581,6 @@ enum class CurrencyCode(val value: String) {
     MYR("MYR"),
 
     /**
-     * Mauritian Rupee (MUR).
-     */
-    @SerializedName("MUR")
-    MUR("MUR"),
-
-    /**
-     * Moldovan Leu (MDL).
-     */
-    @SerializedName("MDL")
-    MDL("MDL"),
-
-    /**
-     * Moroccan Dirham.
-     */
-    @SerializedName("MAD")
-    MAD("MAD"),
-
-    /**
-     * Mongolian Tugrik.
-     */
-    @SerializedName("MNT")
-    MNT("MNT"),
-
-    /**
      * Mozambican Metical.
      */
     @SerializedName("MZN")
@@ -587,22 +593,10 @@ enum class CurrencyCode(val value: String) {
     NAD("NAD"),
 
     /**
-     * Nepalese Rupee (NPR).
+     * Nigerian Naira (NGN).
      */
-    @SerializedName("NPR")
-    NPR("NPR"),
-
-    /**
-     * Netherlands Antillean Guilder.
-     */
-    @SerializedName("ANG")
-    ANG("ANG"),
-
-    /**
-     * New Zealand Dollars (NZD).
-     */
-    @SerializedName("NZD")
-    NZD("NZD"),
+    @SerializedName("NGN")
+    NGN("NGN"),
 
     /**
      * Nicaraguan Córdoba (NIO).
@@ -611,16 +605,22 @@ enum class CurrencyCode(val value: String) {
     NIO("NIO"),
 
     /**
-     * Nigerian Naira (NGN).
-     */
-    @SerializedName("NGN")
-    NGN("NGN"),
-
-    /**
      * Norwegian Kroner (NOK).
      */
     @SerializedName("NOK")
     NOK("NOK"),
+
+    /**
+     * Nepalese Rupee (NPR).
+     */
+    @SerializedName("NPR")
+    NPR("NPR"),
+
+    /**
+     * New Zealand Dollars (NZD).
+     */
+    @SerializedName("NZD")
+    NZD("NZD"),
 
     /**
      * Omani Rial (OMR).
@@ -635,10 +635,10 @@ enum class CurrencyCode(val value: String) {
     PAB("PAB"),
 
     /**
-     * Pakistani Rupee (PKR).
+     * Peruvian Nuevo Sol (PEN).
      */
-    @SerializedName("PKR")
-    PKR("PKR"),
+    @SerializedName("PEN")
+    PEN("PEN"),
 
     /**
      * Papua New Guinean Kina (PGK).
@@ -647,28 +647,28 @@ enum class CurrencyCode(val value: String) {
     PGK("PGK"),
 
     /**
-     * Paraguayan Guarani (PYG).
-     */
-    @SerializedName("PYG")
-    PYG("PYG"),
-
-    /**
-     * Peruvian Nuevo Sol (PEN).
-     */
-    @SerializedName("PEN")
-    PEN("PEN"),
-
-    /**
      * Philippine Peso (PHP).
      */
     @SerializedName("PHP")
     PHP("PHP"),
 
     /**
+     * Pakistani Rupee (PKR).
+     */
+    @SerializedName("PKR")
+    PKR("PKR"),
+
+    /**
      * Polish Zlotych (PLN).
      */
     @SerializedName("PLN")
     PLN("PLN"),
+
+    /**
+     * Paraguayan Guarani (PYG).
+     */
+    @SerializedName("PYG")
+    PYG("PYG"),
 
     /**
      * Qatari Rial (QAR).
@@ -683,6 +683,12 @@ enum class CurrencyCode(val value: String) {
     RON("RON"),
 
     /**
+     * Serbian dinar (RSD).
+     */
+    @SerializedName("RSD")
+    RSD("RSD"),
+
+    /**
      * Russian Rubles (RUB).
      */
     @SerializedName("RUB")
@@ -695,82 +701,10 @@ enum class CurrencyCode(val value: String) {
     RWF("RWF"),
 
     /**
-     * Samoan Tala (WST).
-     */
-    @SerializedName("WST")
-    WST("WST"),
-
-    /**
-     * Saint Helena Pounds (SHP).
-     */
-    @SerializedName("SHP")
-    SHP("SHP"),
-
-    /**
      * Saudi Riyal (SAR).
      */
     @SerializedName("SAR")
     SAR("SAR"),
-
-    /**
-     * Sao Tome And Principe Dobra (STD).
-     */
-    @SerializedName("STD")
-    STD("STD"),
-
-    /**
-     * Serbian dinar (RSD).
-     */
-    @SerializedName("RSD")
-    RSD("RSD"),
-
-    /**
-     * Seychellois Rupee (SCR).
-     */
-    @SerializedName("SCR")
-    SCR("SCR"),
-
-    /**
-     * Sierra Leonean Leone (SLL).
-     */
-    @SerializedName("SLL")
-    SLL("SLL"),
-
-    /**
-     * Singapore Dollars (SGD).
-     */
-    @SerializedName("SGD")
-    SGD("SGD"),
-
-    /**
-     * Sudanese Pound (SDG).
-     */
-    @SerializedName("SDG")
-    SDG("SDG"),
-
-    /**
-     * Syrian Pound (SYP).
-     */
-    @SerializedName("SYP")
-    SYP("SYP"),
-
-    /**
-     * South African Rand (ZAR).
-     */
-    @SerializedName("ZAR")
-    ZAR("ZAR"),
-
-    /**
-     * South Korean Won (KRW).
-     */
-    @SerializedName("KRW")
-    KRW("KRW"),
-
-    /**
-     * South Sudanese Pound (SSP).
-     */
-    @SerializedName("SSP")
-    SSP("SSP"),
 
     /**
      * Solomon Islands Dollar (SBD).
@@ -779,22 +713,16 @@ enum class CurrencyCode(val value: String) {
     SBD("SBD"),
 
     /**
-     * Sri Lankan Rupees (LKR).
+     * Seychellois Rupee (SCR).
      */
-    @SerializedName("LKR")
-    LKR("LKR"),
+    @SerializedName("SCR")
+    SCR("SCR"),
 
     /**
-     * Surinamese Dollar (SRD).
+     * Sudanese Pound (SDG).
      */
-    @SerializedName("SRD")
-    SRD("SRD"),
-
-    /**
-     * Swazi Lilangeni (SZL).
-     */
-    @SerializedName("SZL")
-    SZL("SZL"),
+    @SerializedName("SDG")
+    SDG("SDG"),
 
     /**
      * Swedish Kronor (SEK).
@@ -803,16 +731,52 @@ enum class CurrencyCode(val value: String) {
     SEK("SEK"),
 
     /**
-     * Swiss Francs (CHF).
+     * Singapore Dollars (SGD).
      */
-    @SerializedName("CHF")
-    CHF("CHF"),
+    @SerializedName("SGD")
+    SGD("SGD"),
 
     /**
-     * Taiwan Dollars (TWD).
+     * Saint Helena Pounds (SHP).
      */
-    @SerializedName("TWD")
-    TWD("TWD"),
+    @SerializedName("SHP")
+    SHP("SHP"),
+
+    /**
+     * Sierra Leonean Leone (SLL).
+     */
+    @SerializedName("SLL")
+    SLL("SLL"),
+
+    /**
+     * Surinamese Dollar (SRD).
+     */
+    @SerializedName("SRD")
+    SRD("SRD"),
+
+    /**
+     * South Sudanese Pound (SSP).
+     */
+    @SerializedName("SSP")
+    SSP("SSP"),
+
+    /**
+     * Sao Tome And Principe Dobra (STD).
+     */
+    @SerializedName("STD")
+    STD("STD"),
+
+    /**
+     * Syrian Pound (SYP).
+     */
+    @SerializedName("SYP")
+    SYP("SYP"),
+
+    /**
+     * Swazi Lilangeni (SZL).
+     */
+    @SerializedName("SZL")
+    SZL("SZL"),
 
     /**
      * Thai baht (THB).
@@ -827,22 +791,10 @@ enum class CurrencyCode(val value: String) {
     TJS("TJS"),
 
     /**
-     * Tanzanian Shilling (TZS).
+     * Turkmenistani Manat (TMT).
      */
-    @SerializedName("TZS")
-    TZS("TZS"),
-
-    /**
-     * Tongan Pa'anga (TOP).
-     */
-    @SerializedName("TOP")
-    TOP("TOP"),
-
-    /**
-     * Trinidad and Tobago Dollars (TTD).
-     */
-    @SerializedName("TTD")
-    TTD("TTD"),
+    @SerializedName("TMT")
+    TMT("TMT"),
 
     /**
      * Tunisian Dinar (TND).
@@ -851,22 +803,34 @@ enum class CurrencyCode(val value: String) {
     TND("TND"),
 
     /**
+     * Tongan Pa'anga (TOP).
+     */
+    @SerializedName("TOP")
+    TOP("TOP"),
+
+    /**
      * Turkish Lira (TRY).
      */
     @SerializedName("TRY")
     TRY("TRY"),
 
     /**
-     * Turkmenistani Manat (TMT).
+     * Trinidad and Tobago Dollars (TTD).
      */
-    @SerializedName("TMT")
-    TMT("TMT"),
+    @SerializedName("TTD")
+    TTD("TTD"),
 
     /**
-     * Ugandan Shilling (UGX).
+     * Taiwan Dollars (TWD).
      */
-    @SerializedName("UGX")
-    UGX("UGX"),
+    @SerializedName("TWD")
+    TWD("TWD"),
+
+    /**
+     * Tanzanian Shilling (TZS).
+     */
+    @SerializedName("TZS")
+    TZS("TZS"),
 
     /**
      * Ukrainian Hryvnia (UAH).
@@ -875,10 +839,16 @@ enum class CurrencyCode(val value: String) {
     UAH("UAH"),
 
     /**
-     * United Arab Emirates Dirham (AED).
+     * Ugandan Shilling (UGX).
      */
-    @SerializedName("AED")
-    AED("AED"),
+    @SerializedName("UGX")
+    UGX("UGX"),
+
+    /**
+     * United States Dollars (USD).
+     */
+    @SerializedName("USD")
+    USD("USD"),
 
     /**
      * Uruguayan Pesos (UYU).
@@ -893,12 +863,6 @@ enum class CurrencyCode(val value: String) {
     UZS("UZS"),
 
     /**
-     * Vanuatu Vatu (VUV).
-     */
-    @SerializedName("VUV")
-    VUV("VUV"),
-
-    /**
      * Venezuelan Bolivares (VEF).
      */
     @SerializedName("VEF")
@@ -911,16 +875,52 @@ enum class CurrencyCode(val value: String) {
     VND("VND"),
 
     /**
+     * Vanuatu Vatu (VUV).
+     */
+    @SerializedName("VUV")
+    VUV("VUV"),
+
+    /**
+     * Samoan Tala (WST).
+     */
+    @SerializedName("WST")
+    WST("WST"),
+
+    /**
+     * Central African CFA Franc (XAF).
+     */
+    @SerializedName("XAF")
+    XAF("XAF"),
+
+    /**
+     * East Caribbean Dollar (XCD).
+     */
+    @SerializedName("XCD")
+    XCD("XCD"),
+
+    /**
      * West African CFA franc (XOF).
      */
     @SerializedName("XOF")
     XOF("XOF"),
 
     /**
+     * CFP Franc (XPF).
+     */
+    @SerializedName("XPF")
+    XPF("XPF"),
+
+    /**
      * Yemeni Rial (YER).
      */
     @SerializedName("YER")
     YER("YER"),
+
+    /**
+     * South African Rand (ZAR).
+     */
+    @SerializedName("ZAR")
+    ZAR("ZAR"),
 
     /**
      * Zambian Kwacha (ZMW).

--- a/Tests/Resources/ExpectedKotlinCode/Enums/CustomerMarketingOptInLevel.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/CustomerMarketingOptInLevel.kt
@@ -10,18 +10,18 @@ import javax.annotation.Generated
 enum class CustomerMarketingOptInLevel(val value: String) {
 
     /**
-     * The customer started receiving marketing email(s) after providing their email address, without any
-     * intermediate steps.
-     */
-    @SerializedName("SINGLE_OPT_IN")
-    SINGLE_OPT_IN("SINGLE_OPT_IN"),
-
-    /**
      * After providing their email address, the customer received a confirmation email which required them to
      * perform a prescribed action before receiving marketing emails.
      */
     @SerializedName("CONFIRMED_OPT_IN")
     CONFIRMED_OPT_IN("CONFIRMED_OPT_IN"),
+
+    /**
+     * The customer started receiving marketing email(s) after providing their email address, without any
+     * intermediate steps.
+     */
+    @SerializedName("SINGLE_OPT_IN")
+    SINGLE_OPT_IN("SINGLE_OPT_IN"),
 
     /**
      * The customer receives marketing emails, but the original opt-in process is unknown.

--- a/Tests/Resources/ExpectedKotlinCode/Enums/DigitalWallet.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/DigitalWallet.kt
@@ -10,16 +10,16 @@ import javax.annotation.Generated
 enum class DigitalWallet(val value: String) {
 
     /**
-     * Apple Pay.
-     */
-    @SerializedName("APPLE_PAY")
-    APPLE_PAY("APPLE_PAY"),
-
-    /**
      * Android Pay.
      */
     @SerializedName("ANDROID_PAY")
     ANDROID_PAY("ANDROID_PAY"),
+
+    /**
+     * Apple Pay.
+     */
+    @SerializedName("APPLE_PAY")
+    APPLE_PAY("APPLE_PAY"),
 
     /**
      * Google Pay.

--- a/Tests/Resources/ExpectedKotlinCode/Enums/FulfillmentEventStatus.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/FulfillmentEventStatus.kt
@@ -10,46 +10,16 @@ import javax.annotation.Generated
 enum class FulfillmentEventStatus(val value: String) {
 
     /**
-     * A shipping label has been purchased.
+     * A delivery was attempted.
      */
-    @SerializedName("LABEL_PURCHASED")
-    LABEL_PURCHASED("LABEL_PURCHASED"),
-
-    /**
-     * A purchased shipping label has been printed.
-     */
-    @SerializedName("LABEL_PRINTED")
-    LABEL_PRINTED("LABEL_PRINTED"),
-
-    /**
-     * The fulfillment is ready to be picked up.
-     */
-    @SerializedName("READY_FOR_PICKUP")
-    READY_FOR_PICKUP("READY_FOR_PICKUP"),
+    @SerializedName("ATTEMPTED_DELIVERY")
+    ATTEMPTED_DELIVERY("ATTEMPTED_DELIVERY"),
 
     /**
      * The fulfillment is confirmed.
      */
     @SerializedName("CONFIRMED")
     CONFIRMED("CONFIRMED"),
-
-    /**
-     * The fulfillment is in transit.
-     */
-    @SerializedName("IN_TRANSIT")
-    IN_TRANSIT("IN_TRANSIT"),
-
-    /**
-     * The fulfillment is out for delivery.
-     */
-    @SerializedName("OUT_FOR_DELIVERY")
-    OUT_FOR_DELIVERY("OUT_FOR_DELIVERY"),
-
-    /**
-     * A delivery was attempted.
-     */
-    @SerializedName("ATTEMPTED_DELIVERY")
-    ATTEMPTED_DELIVERY("ATTEMPTED_DELIVERY"),
 
     /**
      * The fulfillment was successfully delivered.
@@ -62,6 +32,36 @@ enum class FulfillmentEventStatus(val value: String) {
      */
     @SerializedName("FAILURE")
     FAILURE("FAILURE"),
+
+    /**
+     * The fulfillment is in transit.
+     */
+    @SerializedName("IN_TRANSIT")
+    IN_TRANSIT("IN_TRANSIT"),
+
+    /**
+     * A purchased shipping label has been printed.
+     */
+    @SerializedName("LABEL_PRINTED")
+    LABEL_PRINTED("LABEL_PRINTED"),
+
+    /**
+     * A shipping label has been purchased.
+     */
+    @SerializedName("LABEL_PURCHASED")
+    LABEL_PURCHASED("LABEL_PURCHASED"),
+
+    /**
+     * The fulfillment is out for delivery.
+     */
+    @SerializedName("OUT_FOR_DELIVERY")
+    OUT_FOR_DELIVERY("OUT_FOR_DELIVERY"),
+
+    /**
+     * The fulfillment is ready to be picked up.
+     */
+    @SerializedName("READY_FOR_PICKUP")
+    READY_FOR_PICKUP("READY_FOR_PICKUP"),
 
     UNKNOWN_SYRUP_ENUM("UNKNOWN_SYRUP_ENUM");
 

--- a/Tests/Resources/ExpectedKotlinCode/Enums/MetafieldValueType.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/MetafieldValueType.kt
@@ -10,12 +10,6 @@ import javax.annotation.Generated
 enum class MetafieldValueType(val value: String) {
 
     /**
-     * A string.
-     */
-    @SerializedName("STRING")
-    STRING("STRING"),
-
-    /**
      * An integer.
      */
     @SerializedName("INTEGER")
@@ -26,6 +20,12 @@ enum class MetafieldValueType(val value: String) {
      */
     @SerializedName("JSON_STRING")
     JSON_STRING("JSON_STRING"),
+
+    /**
+     * A string.
+     */
+    @SerializedName("STRING")
+    STRING("STRING"),
 
     UNKNOWN_SYRUP_ENUM("UNKNOWN_SYRUP_ENUM");
 

--- a/Tests/Resources/ExpectedKotlinCode/Enums/OrderDisplayFulfillmentStatus.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/OrderDisplayFulfillmentStatus.kt
@@ -10,34 +10,16 @@ import javax.annotation.Generated
 enum class OrderDisplayFulfillmentStatus(val value: String) {
 
     /**
-     * Displayed as **Unfulfilled**.
-     */
-    @SerializedName("UNFULFILLED")
-    UNFULFILLED("UNFULFILLED"),
-
-    /**
-     * Displayed as **Partially fulfilled**.
-     */
-    @SerializedName("PARTIALLY_FULFILLED")
-    PARTIALLY_FULFILLED("PARTIALLY_FULFILLED"),
-
-    /**
      * Displayed as **Fulfilled**.
      */
     @SerializedName("FULFILLED")
     FULFILLED("FULFILLED"),
 
     /**
-     * Displayed as **Restocked**.
+     * Displayed as **In progress**.
      */
-    @SerializedName("RESTOCKED")
-    RESTOCKED("RESTOCKED"),
-
-    /**
-     * Displayed as **Pending fulfillment**.
-     */
-    @SerializedName("PENDING_FULFILLMENT")
-    PENDING_FULFILLMENT("PENDING_FULFILLMENT"),
+    @SerializedName("IN_PROGRESS")
+    IN_PROGRESS("IN_PROGRESS"),
 
     /**
      * Displayed as **Open**.
@@ -46,10 +28,28 @@ enum class OrderDisplayFulfillmentStatus(val value: String) {
     OPEN("OPEN"),
 
     /**
-     * Displayed as **In progress**.
+     * Displayed as **Partially fulfilled**.
      */
-    @SerializedName("IN_PROGRESS")
-    IN_PROGRESS("IN_PROGRESS"),
+    @SerializedName("PARTIALLY_FULFILLED")
+    PARTIALLY_FULFILLED("PARTIALLY_FULFILLED"),
+
+    /**
+     * Displayed as **Pending fulfillment**.
+     */
+    @SerializedName("PENDING_FULFILLMENT")
+    PENDING_FULFILLMENT("PENDING_FULFILLMENT"),
+
+    /**
+     * Displayed as **Restocked**.
+     */
+    @SerializedName("RESTOCKED")
+    RESTOCKED("RESTOCKED"),
+
+    /**
+     * Displayed as **Unfulfilled**.
+     */
+    @SerializedName("UNFULFILLED")
+    UNFULFILLED("UNFULFILLED"),
 
     UNKNOWN_SYRUP_ENUM("UNKNOWN_SYRUP_ENUM");
 

--- a/Tests/Resources/ExpectedKotlinCode/Enums/PrivateMetafieldValueType.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/PrivateMetafieldValueType.kt
@@ -12,12 +12,6 @@ enum class PrivateMetafieldValueType(val value: String) {
     /**
      * A private metafield value type.
      */
-    @SerializedName("STRING")
-    STRING("STRING"),
-
-    /**
-     * A private metafield value type.
-     */
     @SerializedName("INTEGER")
     INTEGER("INTEGER"),
 
@@ -26,6 +20,12 @@ enum class PrivateMetafieldValueType(val value: String) {
      */
     @SerializedName("JSON_STRING")
     JSON_STRING("JSON_STRING"),
+
+    /**
+     * A private metafield value type.
+     */
+    @SerializedName("STRING")
+    STRING("STRING"),
 
     UNKNOWN_SYRUP_ENUM("UNKNOWN_SYRUP_ENUM");
 

--- a/Tests/Resources/ExpectedKotlinCode/Enums/ProductVariantInventoryManagement.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/ProductVariantInventoryManagement.kt
@@ -10,10 +10,10 @@ import javax.annotation.Generated
 enum class ProductVariantInventoryManagement(val value: String) {
 
     /**
-     * Shopify tracks this product variant's inventory.
+     * A third-party fulfillment service tracks this product variant's inventory.
      */
-    @SerializedName("SHOPIFY")
-    SHOPIFY("SHOPIFY"),
+    @SerializedName("FULFILLMENT_SERVICE")
+    FULFILLMENT_SERVICE("FULFILLMENT_SERVICE"),
 
     /**
      * This product variant's inventory is not tracked.
@@ -22,10 +22,10 @@ enum class ProductVariantInventoryManagement(val value: String) {
     NOT_MANAGED("NOT_MANAGED"),
 
     /**
-     * A third-party fulfillment service tracks this product variant's inventory.
+     * Shopify tracks this product variant's inventory.
      */
-    @SerializedName("FULFILLMENT_SERVICE")
-    FULFILLMENT_SERVICE("FULFILLMENT_SERVICE"),
+    @SerializedName("SHOPIFY")
+    SHOPIFY("SHOPIFY"),
 
     UNKNOWN_SYRUP_ENUM("UNKNOWN_SYRUP_ENUM");
 

--- a/Tests/Resources/ExpectedKotlinCode/Enums/ProductVariantInventoryPolicy.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/ProductVariantInventoryPolicy.kt
@@ -10,16 +10,16 @@ import javax.annotation.Generated
 enum class ProductVariantInventoryPolicy(val value: String) {
 
     /**
-     * Stop selling a product variant when it is out of stock.
-     */
-    @SerializedName("DENY")
-    DENY("DENY"),
-
-    /**
      * Continue selling a product variant when it is out of stock.
      */
     @SerializedName("CONTINUE")
     CONTINUE("CONTINUE"),
+
+    /**
+     * Stop selling a product variant when it is out of stock.
+     */
+    @SerializedName("DENY")
+    DENY("DENY"),
 
     UNKNOWN_SYRUP_ENUM("UNKNOWN_SYRUP_ENUM");
 

--- a/Tests/Resources/ExpectedKotlinCode/Enums/TaxExemption.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/TaxExemption.kt
@@ -10,10 +10,22 @@ import javax.annotation.Generated
 enum class TaxExemption(val value: String) {
 
     /**
-     * This customer is exempt from specific taxes for holding a valid STATUS_CARD_EXEMPTION in Canada.
+     * This customer is exempt from specific taxes for holding a valid COMMERCIAL_FISHERY_EXEMPTION in British Columbia.
      */
-    @SerializedName("CA_STATUS_CARD_EXEMPTION")
-    CA_STATUS_CARD_EXEMPTION("CA_STATUS_CARD_EXEMPTION"),
+    @SerializedName("CA_BC_COMMERCIAL_FISHERY_EXEMPTION")
+    CA_BC_COMMERCIAL_FISHERY_EXEMPTION("CA_BC_COMMERCIAL_FISHERY_EXEMPTION"),
+
+    /**
+     * This customer is exempt from specific taxes for holding a valid CONTRACTOR_EXEMPTION in British Columbia.
+     */
+    @SerializedName("CA_BC_CONTRACTOR_EXEMPTION")
+    CA_BC_CONTRACTOR_EXEMPTION("CA_BC_CONTRACTOR_EXEMPTION"),
+
+    /**
+     * This customer is exempt from specific taxes for holding a valid PRODUCTION_AND_MACHINERY_EXEMPTION in British Columbia.
+     */
+    @SerializedName("CA_BC_PRODUCTION_AND_MACHINERY_EXEMPTION")
+    CA_BC_PRODUCTION_AND_MACHINERY_EXEMPTION("CA_BC_PRODUCTION_AND_MACHINERY_EXEMPTION"),
 
     /**
      * This customer is exempt from specific taxes for holding a valid RESELLER_EXEMPTION in British Columbia.
@@ -22,16 +34,10 @@ enum class TaxExemption(val value: String) {
     CA_BC_RESELLER_EXEMPTION("CA_BC_RESELLER_EXEMPTION"),
 
     /**
-     * This customer is exempt from specific taxes for holding a valid RESELLER_EXEMPTION in Manitoba.
+     * This customer is exempt from specific taxes for holding a valid SUB_CONTRACTOR_EXEMPTION in British Columbia.
      */
-    @SerializedName("CA_MB_RESELLER_EXEMPTION")
-    CA_MB_RESELLER_EXEMPTION("CA_MB_RESELLER_EXEMPTION"),
-
-    /**
-     * This customer is exempt from specific taxes for holding a valid RESELLER_EXEMPTION in Saskatchewan.
-     */
-    @SerializedName("CA_SK_RESELLER_EXEMPTION")
-    CA_SK_RESELLER_EXEMPTION("CA_SK_RESELLER_EXEMPTION"),
+    @SerializedName("CA_BC_SUB_CONTRACTOR_EXEMPTION")
+    CA_BC_SUB_CONTRACTOR_EXEMPTION("CA_BC_SUB_CONTRACTOR_EXEMPTION"),
 
     /**
      * This customer is exempt from specific taxes for holding a valid DIPLOMAT_EXEMPTION in Canada.
@@ -40,22 +46,40 @@ enum class TaxExemption(val value: String) {
     CA_DIPLOMAT_EXEMPTION("CA_DIPLOMAT_EXEMPTION"),
 
     /**
-     * This customer is exempt from specific taxes for holding a valid COMMERCIAL_FISHERY_EXEMPTION in British Columbia.
-     */
-    @SerializedName("CA_BC_COMMERCIAL_FISHERY_EXEMPTION")
-    CA_BC_COMMERCIAL_FISHERY_EXEMPTION("CA_BC_COMMERCIAL_FISHERY_EXEMPTION"),
-
-    /**
      * This customer is exempt from specific taxes for holding a valid COMMERCIAL_FISHERY_EXEMPTION in Manitoba.
      */
     @SerializedName("CA_MB_COMMERCIAL_FISHERY_EXEMPTION")
     CA_MB_COMMERCIAL_FISHERY_EXEMPTION("CA_MB_COMMERCIAL_FISHERY_EXEMPTION"),
 
     /**
+     * This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Manitoba.
+     */
+    @SerializedName("CA_MB_FARMER_EXEMPTION")
+    CA_MB_FARMER_EXEMPTION("CA_MB_FARMER_EXEMPTION"),
+
+    /**
+     * This customer is exempt from specific taxes for holding a valid RESELLER_EXEMPTION in Manitoba.
+     */
+    @SerializedName("CA_MB_RESELLER_EXEMPTION")
+    CA_MB_RESELLER_EXEMPTION("CA_MB_RESELLER_EXEMPTION"),
+
+    /**
      * This customer is exempt from specific taxes for holding a valid COMMERCIAL_FISHERY_EXEMPTION in Nova Scotia.
      */
     @SerializedName("CA_NS_COMMERCIAL_FISHERY_EXEMPTION")
     CA_NS_COMMERCIAL_FISHERY_EXEMPTION("CA_NS_COMMERCIAL_FISHERY_EXEMPTION"),
+
+    /**
+     * This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Nova Scotia.
+     */
+    @SerializedName("CA_NS_FARMER_EXEMPTION")
+    CA_NS_FARMER_EXEMPTION("CA_NS_FARMER_EXEMPTION"),
+
+    /**
+     * This customer is exempt from specific taxes for holding a valid PURCHASE_EXEMPTION in Ontario.
+     */
+    @SerializedName("CA_ON_PURCHASE_EXEMPTION")
+    CA_ON_PURCHASE_EXEMPTION("CA_ON_PURCHASE_EXEMPTION"),
 
     /**
      * This customer is exempt from specific taxes for holding a valid COMMERCIAL_FISHERY_EXEMPTION in Prince Edward Island.
@@ -70,10 +94,16 @@ enum class TaxExemption(val value: String) {
     CA_SK_COMMERCIAL_FISHERY_EXEMPTION("CA_SK_COMMERCIAL_FISHERY_EXEMPTION"),
 
     /**
-     * This customer is exempt from specific taxes for holding a valid PRODUCTION_AND_MACHINERY_EXEMPTION in British Columbia.
+     * This customer is exempt from specific taxes for holding a valid CONTRACTOR_EXEMPTION in Saskatchewan.
      */
-    @SerializedName("CA_BC_PRODUCTION_AND_MACHINERY_EXEMPTION")
-    CA_BC_PRODUCTION_AND_MACHINERY_EXEMPTION("CA_BC_PRODUCTION_AND_MACHINERY_EXEMPTION"),
+    @SerializedName("CA_SK_CONTRACTOR_EXEMPTION")
+    CA_SK_CONTRACTOR_EXEMPTION("CA_SK_CONTRACTOR_EXEMPTION"),
+
+    /**
+     * This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Saskatchewan.
+     */
+    @SerializedName("CA_SK_FARMER_EXEMPTION")
+    CA_SK_FARMER_EXEMPTION("CA_SK_FARMER_EXEMPTION"),
 
     /**
      * This customer is exempt from specific taxes for holding a valid PRODUCTION_AND_MACHINERY_EXEMPTION in Saskatchewan.
@@ -82,10 +112,10 @@ enum class TaxExemption(val value: String) {
     CA_SK_PRODUCTION_AND_MACHINERY_EXEMPTION("CA_SK_PRODUCTION_AND_MACHINERY_EXEMPTION"),
 
     /**
-     * This customer is exempt from specific taxes for holding a valid SUB_CONTRACTOR_EXEMPTION in British Columbia.
+     * This customer is exempt from specific taxes for holding a valid RESELLER_EXEMPTION in Saskatchewan.
      */
-    @SerializedName("CA_BC_SUB_CONTRACTOR_EXEMPTION")
-    CA_BC_SUB_CONTRACTOR_EXEMPTION("CA_BC_SUB_CONTRACTOR_EXEMPTION"),
+    @SerializedName("CA_SK_RESELLER_EXEMPTION")
+    CA_SK_RESELLER_EXEMPTION("CA_SK_RESELLER_EXEMPTION"),
 
     /**
      * This customer is exempt from specific taxes for holding a valid SUB_CONTRACTOR_EXEMPTION in Saskatchewan.
@@ -94,40 +124,10 @@ enum class TaxExemption(val value: String) {
     CA_SK_SUB_CONTRACTOR_EXEMPTION("CA_SK_SUB_CONTRACTOR_EXEMPTION"),
 
     /**
-     * This customer is exempt from specific taxes for holding a valid CONTRACTOR_EXEMPTION in British Columbia.
+     * This customer is exempt from specific taxes for holding a valid STATUS_CARD_EXEMPTION in Canada.
      */
-    @SerializedName("CA_BC_CONTRACTOR_EXEMPTION")
-    CA_BC_CONTRACTOR_EXEMPTION("CA_BC_CONTRACTOR_EXEMPTION"),
-
-    /**
-     * This customer is exempt from specific taxes for holding a valid CONTRACTOR_EXEMPTION in Saskatchewan.
-     */
-    @SerializedName("CA_SK_CONTRACTOR_EXEMPTION")
-    CA_SK_CONTRACTOR_EXEMPTION("CA_SK_CONTRACTOR_EXEMPTION"),
-
-    /**
-     * This customer is exempt from specific taxes for holding a valid PURCHASE_EXEMPTION in Ontario.
-     */
-    @SerializedName("CA_ON_PURCHASE_EXEMPTION")
-    CA_ON_PURCHASE_EXEMPTION("CA_ON_PURCHASE_EXEMPTION"),
-
-    /**
-     * This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Manitoba.
-     */
-    @SerializedName("CA_MB_FARMER_EXEMPTION")
-    CA_MB_FARMER_EXEMPTION("CA_MB_FARMER_EXEMPTION"),
-
-    /**
-     * This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Nova Scotia.
-     */
-    @SerializedName("CA_NS_FARMER_EXEMPTION")
-    CA_NS_FARMER_EXEMPTION("CA_NS_FARMER_EXEMPTION"),
-
-    /**
-     * This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Saskatchewan.
-     */
-    @SerializedName("CA_SK_FARMER_EXEMPTION")
-    CA_SK_FARMER_EXEMPTION("CA_SK_FARMER_EXEMPTION"),
+    @SerializedName("CA_STATUS_CARD_EXEMPTION")
+    CA_STATUS_CARD_EXEMPTION("CA_STATUS_CARD_EXEMPTION"),
 
     UNKNOWN_SYRUP_ENUM("UNKNOWN_SYRUP_ENUM");
 

--- a/Tests/Resources/ExpectedKotlinCode/Enums/WeightUnit.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Enums/WeightUnit.kt
@@ -10,28 +10,28 @@ import javax.annotation.Generated
 enum class WeightUnit(val value: String) {
 
     /**
-     * 1 kilogram equals 1000 grams.
-     */
-    @SerializedName("KILOGRAMS")
-    KILOGRAMS("KILOGRAMS"),
-
-    /**
      * Metric system unit of mass.
      */
     @SerializedName("GRAMS")
     GRAMS("GRAMS"),
 
     /**
-     * 1 pound equals 16 ounces.
+     * 1 kilogram equals 1000 grams.
      */
-    @SerializedName("POUNDS")
-    POUNDS("POUNDS"),
+    @SerializedName("KILOGRAMS")
+    KILOGRAMS("KILOGRAMS"),
 
     /**
      * Imperial system unit of mass.
      */
     @SerializedName("OUNCES")
     OUNCES("OUNCES"),
+
+    /**
+     * 1 pound equals 16 ounces.
+     */
+    @SerializedName("POUNDS")
+    POUNDS("POUNDS"),
 
     UNKNOWN_SYRUP_ENUM("UNKNOWN_SYRUP_ENUM");
 

--- a/Tests/Resources/ExpectedSwiftCode/Enums/CountryCodeNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Enums/CountryCodeNext.swift
@@ -3,486 +3,486 @@ import Foundation
 
 public extension MerchantApi {
 	enum CountryCode: String, Codable {
-		/// Afghanistan.
-			case af = "AF"
-		/// Aland Islands.
-			case ax = "AX"
-		/// Albania.
-			case al = "AL"
-		/// Algeria.
-			case dz = "DZ"
 		/// Andorra.
 			case ad = "AD"
-		/// Angola.
-			case ao = "AO"
-		/// Anguilla.
-			case ai = "AI"
+		/// United Arab Emirates.
+			case ae = "AE"
+		/// Afghanistan.
+			case af = "AF"
 		/// Antigua And Barbuda.
 			case ag = "AG"
-		/// Argentina.
-			case ar = "AR"
+		/// Anguilla.
+			case ai = "AI"
+		/// Albania.
+			case al = "AL"
 		/// Armenia.
 			case am = "AM"
-		/// Aruba.
-			case aw = "AW"
-		/// Australia.
-			case au = "AU"
+		/// Netherlands Antilles.
+			case an = "AN"
+		/// Angola.
+			case ao = "AO"
+		/// Argentina.
+			case ar = "AR"
 		/// Austria.
 			case at = "AT"
+		/// Australia.
+			case au = "AU"
+		/// Aruba.
+			case aw = "AW"
+		/// Aland Islands.
+			case ax = "AX"
 		/// Azerbaijan.
 			case az = "AZ"
-		/// Bahamas.
-			case bs = "BS"
-		/// Bahrain.
-			case bh = "BH"
-		/// Bangladesh.
-			case bd = "BD"
-		/// Barbados.
-			case bb = "BB"
-		/// Belarus.
-			case by = "BY"
-		/// Belgium.
-			case be = "BE"
-		/// Belize.
-			case bz = "BZ"
-		/// Benin.
-			case bj = "BJ"
-		/// Bermuda.
-			case bm = "BM"
-		/// Bhutan.
-			case bt = "BT"
-		/// Bolivia.
-			case bo = "BO"
 		/// Bosnia And Herzegovina.
 			case ba = "BA"
-		/// Botswana.
-			case bw = "BW"
-		/// Bouvet Island.
-			case bv = "BV"
-		/// Brazil.
-			case br = "BR"
-		/// British Indian Ocean Territory.
-			case io = "IO"
-		/// Brunei.
-			case bn = "BN"
-		/// Bulgaria.
-			case bg = "BG"
+		/// Barbados.
+			case bb = "BB"
+		/// Bangladesh.
+			case bd = "BD"
+		/// Belgium.
+			case be = "BE"
 		/// Burkina Faso.
 			case bf = "BF"
+		/// Bulgaria.
+			case bg = "BG"
+		/// Bahrain.
+			case bh = "BH"
 		/// Burundi.
 			case bi = "BI"
-		/// Cambodia.
-			case kh = "KH"
-		/// Canada.
-			case ca = "CA"
-		/// Cape Verde.
-			case cv = "CV"
+		/// Benin.
+			case bj = "BJ"
+		/// Saint Barthélemy.
+			case bl = "BL"
+		/// Bermuda.
+			case bm = "BM"
+		/// Brunei.
+			case bn = "BN"
+		/// Bolivia.
+			case bo = "BO"
 		/// Caribbean Netherlands.
 			case bq = "BQ"
-		/// Cayman Islands.
-			case ky = "KY"
-		/// Central African Republic.
-			case cf = "CF"
-		/// Chad.
-			case td = "TD"
-		/// Chile.
-			case cl = "CL"
-		/// China.
-			case cn = "CN"
-		/// Christmas Island.
-			case cx = "CX"
+		/// Brazil.
+			case br = "BR"
+		/// Bahamas.
+			case bs = "BS"
+		/// Bhutan.
+			case bt = "BT"
+		/// Bouvet Island.
+			case bv = "BV"
+		/// Botswana.
+			case bw = "BW"
+		/// Belarus.
+			case by = "BY"
+		/// Belize.
+			case bz = "BZ"
+		/// Canada.
+			case ca = "CA"
 		/// Cocos (Keeling) Islands.
 			case cc = "CC"
-		/// Colombia.
-			case co = "CO"
-		/// Comoros.
-			case km = "KM"
-		/// Congo.
-			case cg = "CG"
 		/// Congo, The Democratic Republic Of The.
 			case cd = "CD"
+		/// Central African Republic.
+			case cf = "CF"
+		/// Congo.
+			case cg = "CG"
+		/// Switzerland.
+			case ch = "CH"
+		/// Côte d'Ivoire.
+			case ci = "CI"
 		/// Cook Islands.
 			case ck = "CK"
+		/// Chile.
+			case cl = "CL"
+		/// Republic of Cameroon.
+			case cm = "CM"
+		/// China.
+			case cn = "CN"
+		/// Colombia.
+			case co = "CO"
 		/// Costa Rica.
 			case cr = "CR"
-		/// Croatia.
-			case hr = "HR"
 		/// Cuba.
 			case cu = "CU"
+		/// Cape Verde.
+			case cv = "CV"
 		/// Curaçao.
 			case cw = "CW"
+		/// Christmas Island.
+			case cx = "CX"
 		/// Cyprus.
 			case cy = "CY"
 		/// Czech Republic.
 			case cz = "CZ"
-		/// Côte d'Ivoire.
-			case ci = "CI"
-		/// Denmark.
-			case dk = "DK"
+		/// Germany.
+			case de = "DE"
 		/// Djibouti.
 			case dj = "DJ"
+		/// Denmark.
+			case dk = "DK"
 		/// Dominica.
 			case dm = "DM"
 		/// Dominican Republic.
 			case `do` = "DO"
+		/// Algeria.
+			case dz = "DZ"
 		/// Ecuador.
 			case ec = "EC"
-		/// Egypt.
-			case eg = "EG"
-		/// El Salvador.
-			case sv = "SV"
-		/// Equatorial Guinea.
-			case gq = "GQ"
-		/// Eritrea.
-			case er = "ER"
 		/// Estonia.
 			case ee = "EE"
-		/// Eswatini.
-			case sz = "SZ"
+		/// Egypt.
+			case eg = "EG"
+		/// Western Sahara.
+			case eh = "EH"
+		/// Eritrea.
+			case er = "ER"
+		/// Spain.
+			case es = "ES"
 		/// Ethiopia.
 			case et = "ET"
+		/// Finland.
+			case fi = "FI"
+		/// Fiji.
+			case fj = "FJ"
 		/// Falkland Islands (Malvinas).
 			case fk = "FK"
 		/// Faroe Islands.
 			case fo = "FO"
-		/// Fiji.
-			case fj = "FJ"
-		/// Finland.
-			case fi = "FI"
 		/// France.
 			case fr = "FR"
-		/// French Guiana.
-			case gf = "GF"
-		/// French Polynesia.
-			case pf = "PF"
-		/// French Southern Territories.
-			case tf = "TF"
 		/// Gabon.
 			case ga = "GA"
-		/// Gambia.
-			case gm = "GM"
+		/// United Kingdom.
+			case gb = "GB"
+		/// Grenada.
+			case gd = "GD"
 		/// Georgia.
 			case ge = "GE"
-		/// Germany.
-			case de = "DE"
+		/// French Guiana.
+			case gf = "GF"
+		/// Guernsey.
+			case gg = "GG"
 		/// Ghana.
 			case gh = "GH"
 		/// Gibraltar.
 			case gi = "GI"
-		/// Greece.
-			case gr = "GR"
 		/// Greenland.
 			case gl = "GL"
-		/// Grenada.
-			case gd = "GD"
-		/// Guadeloupe.
-			case gp = "GP"
-		/// Guatemala.
-			case gt = "GT"
-		/// Guernsey.
-			case gg = "GG"
+		/// Gambia.
+			case gm = "GM"
 		/// Guinea.
 			case gn = "GN"
+		/// Guadeloupe.
+			case gp = "GP"
+		/// Equatorial Guinea.
+			case gq = "GQ"
+		/// Greece.
+			case gr = "GR"
+		/// South Georgia And The South Sandwich Islands.
+			case gs = "GS"
+		/// Guatemala.
+			case gt = "GT"
 		/// Guinea Bissau.
 			case gw = "GW"
 		/// Guyana.
 			case gy = "GY"
-		/// Haiti.
-			case ht = "HT"
-		/// Heard Island And Mcdonald Islands.
-			case hm = "HM"
-		/// Holy See (Vatican City State).
-			case va = "VA"
-		/// Honduras.
-			case hn = "HN"
 		/// Hong Kong.
 			case hk = "HK"
+		/// Heard Island And Mcdonald Islands.
+			case hm = "HM"
+		/// Honduras.
+			case hn = "HN"
+		/// Croatia.
+			case hr = "HR"
+		/// Haiti.
+			case ht = "HT"
 		/// Hungary.
 			case hu = "HU"
-		/// Iceland.
-			case `is` = "IS"
-		/// India.
-			case `in` = "IN"
 		/// Indonesia.
 			case id = "ID"
-		/// Iran, Islamic Republic Of.
-			case ir = "IR"
-		/// Iraq.
-			case iq = "IQ"
 		/// Ireland.
 			case ie = "IE"
-		/// Isle Of Man.
-			case im = "IM"
 		/// Israel.
 			case il = "IL"
+		/// Isle Of Man.
+			case im = "IM"
+		/// India.
+			case `in` = "IN"
+		/// British Indian Ocean Territory.
+			case io = "IO"
+		/// Iraq.
+			case iq = "IQ"
+		/// Iran, Islamic Republic Of.
+			case ir = "IR"
+		/// Iceland.
+			case `is` = "IS"
 		/// Italy.
 			case it = "IT"
-		/// Jamaica.
-			case jm = "JM"
-		/// Japan.
-			case jp = "JP"
 		/// Jersey.
 			case je = "JE"
+		/// Jamaica.
+			case jm = "JM"
 		/// Jordan.
 			case jo = "JO"
-		/// Kazakhstan.
-			case kz = "KZ"
+		/// Japan.
+			case jp = "JP"
 		/// Kenya.
 			case ke = "KE"
-		/// Kiribati.
-			case ki = "KI"
-		/// Korea, Democratic People's Republic Of.
-			case kp = "KP"
-		/// Kosovo.
-			case xk = "XK"
-		/// Kuwait.
-			case kw = "KW"
 		/// Kyrgyzstan.
 			case kg = "KG"
+		/// Cambodia.
+			case kh = "KH"
+		/// Kiribati.
+			case ki = "KI"
+		/// Comoros.
+			case km = "KM"
+		/// Saint Kitts And Nevis.
+			case kn = "KN"
+		/// Korea, Democratic People's Republic Of.
+			case kp = "KP"
+		/// South Korea.
+			case kr = "KR"
+		/// Kuwait.
+			case kw = "KW"
+		/// Cayman Islands.
+			case ky = "KY"
+		/// Kazakhstan.
+			case kz = "KZ"
 		/// Lao People's Democratic Republic.
 			case la = "LA"
-		/// Latvia.
-			case lv = "LV"
 		/// Lebanon.
 			case lb = "LB"
-		/// Lesotho.
-			case ls = "LS"
-		/// Liberia.
-			case lr = "LR"
-		/// Libyan Arab Jamahiriya.
-			case ly = "LY"
+		/// Saint Lucia.
+			case lc = "LC"
 		/// Liechtenstein.
 			case li = "LI"
+		/// Sri Lanka.
+			case lk = "LK"
+		/// Liberia.
+			case lr = "LR"
+		/// Lesotho.
+			case ls = "LS"
 		/// Lithuania.
 			case lt = "LT"
 		/// Luxembourg.
 			case lu = "LU"
-		/// Macao.
-			case mo = "MO"
+		/// Latvia.
+			case lv = "LV"
+		/// Libyan Arab Jamahiriya.
+			case ly = "LY"
+		/// Morocco.
+			case ma = "MA"
+		/// Monaco.
+			case mc = "MC"
+		/// Moldova, Republic of.
+			case md = "MD"
+		/// Montenegro.
+			case me = "ME"
+		/// Saint Martin.
+			case mf = "MF"
 		/// Madagascar.
 			case mg = "MG"
-		/// Malawi.
-			case mw = "MW"
-		/// Malaysia.
-			case my = "MY"
-		/// Maldives.
-			case mv = "MV"
+		/// North Macedonia.
+			case mk = "MK"
 		/// Mali.
 			case ml = "ML"
-		/// Malta.
-			case mt = "MT"
+		/// Myanmar.
+			case mm = "MM"
+		/// Mongolia.
+			case mn = "MN"
+		/// Macao.
+			case mo = "MO"
 		/// Martinique.
 			case mq = "MQ"
 		/// Mauritania.
 			case mr = "MR"
-		/// Mauritius.
-			case mu = "MU"
-		/// Mayotte.
-			case yt = "YT"
-		/// Mexico.
-			case mx = "MX"
-		/// Moldova, Republic of.
-			case md = "MD"
-		/// Monaco.
-			case mc = "MC"
-		/// Mongolia.
-			case mn = "MN"
-		/// Montenegro.
-			case me = "ME"
 		/// Montserrat.
 			case ms = "MS"
-		/// Morocco.
-			case ma = "MA"
+		/// Malta.
+			case mt = "MT"
+		/// Mauritius.
+			case mu = "MU"
+		/// Maldives.
+			case mv = "MV"
+		/// Malawi.
+			case mw = "MW"
+		/// Mexico.
+			case mx = "MX"
+		/// Malaysia.
+			case my = "MY"
 		/// Mozambique.
 			case mz = "MZ"
-		/// Myanmar.
-			case mm = "MM"
 		/// Namibia.
 			case na = "NA"
-		/// Nauru.
-			case nr = "NR"
-		/// Nepal.
-			case np = "NP"
-		/// Netherlands.
-			case nl = "NL"
-		/// Netherlands Antilles.
-			case an = "AN"
 		/// New Caledonia.
 			case nc = "NC"
-		/// New Zealand.
-			case nz = "NZ"
-		/// Nicaragua.
-			case ni = "NI"
 		/// Niger.
 			case ne = "NE"
-		/// Nigeria.
-			case ng = "NG"
-		/// Niue.
-			case nu = "NU"
 		/// Norfolk Island.
 			case nf = "NF"
-		/// North Macedonia.
-			case mk = "MK"
+		/// Nigeria.
+			case ng = "NG"
+		/// Nicaragua.
+			case ni = "NI"
+		/// Netherlands.
+			case nl = "NL"
 		/// Norway.
 			case no = "NO"
+		/// Nepal.
+			case np = "NP"
+		/// Nauru.
+			case nr = "NR"
+		/// Niue.
+			case nu = "NU"
+		/// New Zealand.
+			case nz = "NZ"
 		/// Oman.
 			case om = "OM"
-		/// Pakistan.
-			case pk = "PK"
-		/// Palestinian Territory, Occupied.
-			case ps = "PS"
 		/// Panama.
 			case pa = "PA"
-		/// Papua New Guinea.
-			case pg = "PG"
-		/// Paraguay.
-			case py = "PY"
 		/// Peru.
 			case pe = "PE"
+		/// French Polynesia.
+			case pf = "PF"
+		/// Papua New Guinea.
+			case pg = "PG"
 		/// Philippines.
 			case ph = "PH"
-		/// Pitcairn.
-			case pn = "PN"
+		/// Pakistan.
+			case pk = "PK"
 		/// Poland.
 			case pl = "PL"
+		/// Saint Pierre And Miquelon.
+			case pm = "PM"
+		/// Pitcairn.
+			case pn = "PN"
+		/// Palestinian Territory, Occupied.
+			case ps = "PS"
 		/// Portugal.
 			case pt = "PT"
+		/// Paraguay.
+			case py = "PY"
 		/// Qatar.
 			case qa = "QA"
-		/// Republic of Cameroon.
-			case cm = "CM"
 		/// Reunion.
 			case re = "RE"
 		/// Romania.
 			case ro = "RO"
+		/// Serbia.
+			case rs = "RS"
 		/// Russia.
 			case ru = "RU"
 		/// Rwanda.
 			case rw = "RW"
-		/// Saint Barthélemy.
-			case bl = "BL"
-		/// Saint Helena.
-			case sh = "SH"
-		/// Saint Kitts And Nevis.
-			case kn = "KN"
-		/// Saint Lucia.
-			case lc = "LC"
-		/// Saint Martin.
-			case mf = "MF"
-		/// Saint Pierre And Miquelon.
-			case pm = "PM"
-		/// Samoa.
-			case ws = "WS"
-		/// San Marino.
-			case sm = "SM"
-		/// Sao Tome And Principe.
-			case st = "ST"
 		/// Saudi Arabia.
 			case sa = "SA"
-		/// Senegal.
-			case sn = "SN"
-		/// Serbia.
-			case rs = "RS"
-		/// Seychelles.
-			case sc = "SC"
-		/// Sierra Leone.
-			case sl = "SL"
-		/// Singapore.
-			case sg = "SG"
-		/// Sint Maarten.
-			case sx = "SX"
-		/// Slovakia.
-			case sk = "SK"
-		/// Slovenia.
-			case si = "SI"
 		/// Solomon Islands.
 			case sb = "SB"
-		/// Somalia.
-			case so = "SO"
-		/// South Africa.
-			case za = "ZA"
-		/// South Georgia And The South Sandwich Islands.
-			case gs = "GS"
-		/// South Korea.
-			case kr = "KR"
-		/// South Sudan.
-			case ss = "SS"
-		/// Spain.
-			case es = "ES"
-		/// Sri Lanka.
-			case lk = "LK"
-		/// St. Vincent.
-			case vc = "VC"
+		/// Seychelles.
+			case sc = "SC"
 		/// Sudan.
 			case sd = "SD"
-		/// Suriname.
-			case sr = "SR"
-		/// Svalbard And Jan Mayen.
-			case sj = "SJ"
 		/// Sweden.
 			case se = "SE"
-		/// Switzerland.
-			case ch = "CH"
+		/// Singapore.
+			case sg = "SG"
+		/// Saint Helena.
+			case sh = "SH"
+		/// Slovenia.
+			case si = "SI"
+		/// Svalbard And Jan Mayen.
+			case sj = "SJ"
+		/// Slovakia.
+			case sk = "SK"
+		/// Sierra Leone.
+			case sl = "SL"
+		/// San Marino.
+			case sm = "SM"
+		/// Senegal.
+			case sn = "SN"
+		/// Somalia.
+			case so = "SO"
+		/// Suriname.
+			case sr = "SR"
+		/// South Sudan.
+			case ss = "SS"
+		/// Sao Tome And Principe.
+			case st = "ST"
+		/// El Salvador.
+			case sv = "SV"
+		/// Sint Maarten.
+			case sx = "SX"
 		/// Syria.
 			case sy = "SY"
-		/// Taiwan.
-			case tw = "TW"
-		/// Tajikistan.
-			case tj = "TJ"
-		/// Tanzania, United Republic Of.
-			case tz = "TZ"
-		/// Thailand.
-			case th = "TH"
-		/// Timor Leste.
-			case tl = "TL"
-		/// Togo.
-			case tg = "TG"
-		/// Tokelau.
-			case tk = "TK"
-		/// Tonga.
-			case to = "TO"
-		/// Trinidad and Tobago.
-			case tt = "TT"
-		/// Tunisia.
-			case tn = "TN"
-		/// Turkey.
-			case tr = "TR"
-		/// Turkmenistan.
-			case tm = "TM"
+		/// Eswatini.
+			case sz = "SZ"
 		/// Turks and Caicos Islands.
 			case tc = "TC"
+		/// Chad.
+			case td = "TD"
+		/// French Southern Territories.
+			case tf = "TF"
+		/// Togo.
+			case tg = "TG"
+		/// Thailand.
+			case th = "TH"
+		/// Tajikistan.
+			case tj = "TJ"
+		/// Tokelau.
+			case tk = "TK"
+		/// Timor Leste.
+			case tl = "TL"
+		/// Turkmenistan.
+			case tm = "TM"
+		/// Tunisia.
+			case tn = "TN"
+		/// Tonga.
+			case to = "TO"
+		/// Turkey.
+			case tr = "TR"
+		/// Trinidad and Tobago.
+			case tt = "TT"
 		/// Tuvalu.
 			case tv = "TV"
-		/// Uganda.
-			case ug = "UG"
+		/// Taiwan.
+			case tw = "TW"
+		/// Tanzania, United Republic Of.
+			case tz = "TZ"
 		/// Ukraine.
 			case ua = "UA"
-		/// United Arab Emirates.
-			case ae = "AE"
-		/// United Kingdom.
-			case gb = "GB"
-		/// United States.
-			case us = "US"
+		/// Uganda.
+			case ug = "UG"
 		/// United States Minor Outlying Islands.
 			case um = "UM"
+		/// United States.
+			case us = "US"
 		/// Uruguay.
 			case uy = "UY"
 		/// Uzbekistan.
 			case uz = "UZ"
-		/// Vanuatu.
-			case vu = "VU"
+		/// Holy See (Vatican City State).
+			case va = "VA"
+		/// St. Vincent.
+			case vc = "VC"
 		/// Venezuela.
 			case ve = "VE"
-		/// Vietnam.
-			case vn = "VN"
 		/// Virgin Islands, British.
 			case vg = "VG"
+		/// Vietnam.
+			case vn = "VN"
+		/// Vanuatu.
+			case vu = "VU"
 		/// Wallis And Futuna.
 			case wf = "WF"
-		/// Western Sahara.
-			case eh = "EH"
+		/// Samoa.
+			case ws = "WS"
+		/// Kosovo.
+			case xk = "XK"
 		/// Yemen.
 			case ye = "YE"
+		/// Mayotte.
+			case yt = "YT"
+		/// South Africa.
+			case za = "ZA"
 		/// Zambia.
 			case zm = "ZM"
 		/// Zimbabwe.

--- a/Tests/Resources/ExpectedSwiftCode/Enums/CurrencyCodeNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Enums/CurrencyCodeNext.swift
@@ -3,42 +3,52 @@ import Foundation
 
 public extension MerchantApi {
 	enum CurrencyCode: String, Codable {
-		/// United States Dollars (USD).
-			case usd = "USD"
-		/// Euro (EUR).
-			case eur = "EUR"
-		/// United Kingdom Pounds (GBP).
-			case gbp = "GBP"
-		/// Canadian Dollars (CAD).
-			case cad = "CAD"
+		/// United Arab Emirates Dirham (AED).
+			case aed = "AED"
 		/// Afghan Afghani (AFN).
 			case afn = "AFN"
 		/// Albanian Lek (ALL).
 			case all = "ALL"
-		/// Algerian Dinar (DZD).
-			case dzd = "DZD"
+		/// Armenian Dram (AMD).
+			case amd = "AMD"
+		/// Netherlands Antillean Guilder.
+			case ang = "ANG"
 		/// Angolan Kwanza (AOA).
 			case aoa = "AOA"
 		/// Argentine Pesos (ARS).
 			case ars = "ARS"
-		/// Armenian Dram (AMD).
-			case amd = "AMD"
-		/// Aruban Florin (AWG).
-			case awg = "AWG"
 		/// Australian Dollars (AUD).
 			case aud = "AUD"
-		/// Barbadian Dollar (BBD).
-			case bbd = "BBD"
+		/// Aruban Florin (AWG).
+			case awg = "AWG"
 		/// Azerbaijani Manat (AZN).
 			case azn = "AZN"
+		/// Bosnia and Herzegovina Convertible Mark (BAM).
+			case bam = "BAM"
+		/// Barbadian Dollar (BBD).
+			case bbd = "BBD"
 		/// Bangladesh Taka (BDT).
 			case bdt = "BDT"
-		/// Bahamian Dollar (BSD).
-			case bsd = "BSD"
+		/// Bulgarian Lev (BGN).
+			case bgn = "BGN"
 		/// Bahraini Dinar (BHD).
 			case bhd = "BHD"
 		/// Burundian Franc (BIF).
 			case bif = "BIF"
+		/// Bermudian Dollar (BMD).
+			case bmd = "BMD"
+		/// Brunei Dollar (BND).
+			case bnd = "BND"
+		/// Bolivian Boliviano (BOB).
+			case bob = "BOB"
+		/// Brazilian Real (BRL).
+			case brl = "BRL"
+		/// Bahamian Dollar (BSD).
+			case bsd = "BSD"
+		/// Bhutanese Ngultrum (BTN).
+			case btn = "BTN"
+		/// Botswana Pula (BWP).
+			case bwp = "BWP"
 		/// Belarusian Ruble (BYN).
 			case byn = "BYN"
 		/// Belarusian Ruble (BYR).
@@ -48,268 +58,258 @@ public extension MerchantApi {
 			case byr = "BYR"
 		/// Belize Dollar (BZD).
 			case bzd = "BZD"
-		/// Bermudian Dollar (BMD).
-			case bmd = "BMD"
-		/// Bhutanese Ngultrum (BTN).
-			case btn = "BTN"
-		/// Bosnia and Herzegovina Convertible Mark (BAM).
-			case bam = "BAM"
-		/// Brazilian Real (BRL).
-			case brl = "BRL"
-		/// Bolivian Boliviano (BOB).
-			case bob = "BOB"
-		/// Botswana Pula (BWP).
-			case bwp = "BWP"
-		/// Brunei Dollar (BND).
-			case bnd = "BND"
-		/// Bulgarian Lev (BGN).
-			case bgn = "BGN"
-		/// Burmese Kyat (MMK).
-			case mmk = "MMK"
-		/// Cambodian Riel.
-			case khr = "KHR"
-		/// Cape Verdean escudo (CVE).
-			case cve = "CVE"
-		/// Cayman Dollars (KYD).
-			case kyd = "KYD"
-		/// Central African CFA Franc (XAF).
-			case xaf = "XAF"
+		/// Canadian Dollars (CAD).
+			case cad = "CAD"
+		/// Congolese franc (CDF).
+			case cdf = "CDF"
+		/// Swiss Francs (CHF).
+			case chf = "CHF"
 		/// Chilean Peso (CLP).
 			case clp = "CLP"
 		/// Chinese Yuan Renminbi (CNY).
 			case cny = "CNY"
 		/// Colombian Peso (COP).
 			case cop = "COP"
-		/// Comorian Franc (KMF).
-			case kmf = "KMF"
-		/// Congolese franc (CDF).
-			case cdf = "CDF"
 		/// Costa Rican Colones (CRC).
 			case crc = "CRC"
-		/// Croatian Kuna (HRK).
-			case hrk = "HRK"
+		/// Cape Verdean escudo (CVE).
+			case cve = "CVE"
 		/// Czech Koruny (CZK).
 			case czk = "CZK"
-		/// Danish Kroner (DKK).
-			case dkk = "DKK"
 		/// Djiboutian Franc (DJF).
 			case djf = "DJF"
+		/// Danish Kroner (DKK).
+			case dkk = "DKK"
 		/// Dominican Peso (DOP).
 			case dop = "DOP"
-		/// East Caribbean Dollar (XCD).
-			case xcd = "XCD"
+		/// Algerian Dinar (DZD).
+			case dzd = "DZD"
 		/// Egyptian Pound (EGP).
 			case egp = "EGP"
 		/// Ethiopian Birr (ETB).
 			case etb = "ETB"
-		/// Falkland Islands Pounds (FKP).
-			case fkp = "FKP"
-		/// CFP Franc (XPF).
-			case xpf = "XPF"
+		/// Euro (EUR).
+			case eur = "EUR"
 		/// Fijian Dollars (FJD).
 			case fjd = "FJD"
+		/// Falkland Islands Pounds (FKP).
+			case fkp = "FKP"
+		/// United Kingdom Pounds (GBP).
+			case gbp = "GBP"
+		/// Georgian Lari (GEL).
+			case gel = "GEL"
+		/// Ghanaian Cedi (GHS).
+			case ghs = "GHS"
 		/// Gibraltar Pounds (GIP).
 			case gip = "GIP"
 		/// Gambian Dalasi (GMD).
 			case gmd = "GMD"
-		/// Ghanaian Cedi (GHS).
-			case ghs = "GHS"
+		/// Guinean Franc (GNF).
+			case gnf = "GNF"
 		/// Guatemalan Quetzal (GTQ).
 			case gtq = "GTQ"
 		/// Guyanese Dollar (GYD).
 			case gyd = "GYD"
-		/// Georgian Lari (GEL).
-			case gel = "GEL"
-		/// Guinean Franc (GNF).
-			case gnf = "GNF"
-		/// Haitian Gourde (HTG).
-			case htg = "HTG"
-		/// Honduran Lempira (HNL).
-			case hnl = "HNL"
 		/// Hong Kong Dollars (HKD).
 			case hkd = "HKD"
+		/// Honduran Lempira (HNL).
+			case hnl = "HNL"
+		/// Croatian Kuna (HRK).
+			case hrk = "HRK"
+		/// Haitian Gourde (HTG).
+			case htg = "HTG"
 		/// Hungarian Forint (HUF).
 			case huf = "HUF"
-		/// Icelandic Kronur (ISK).
-			case isk = "ISK"
-		/// Indian Rupees (INR).
-			case inr = "INR"
 		/// Indonesian Rupiah (IDR).
 			case idr = "IDR"
 		/// Israeli New Shekel (NIS).
 			case ils = "ILS"
-		/// Iranian Rial (IRR).
-			case irr = "IRR"
+		/// Indian Rupees (INR).
+			case inr = "INR"
 		/// Iraqi Dinar (IQD).
 			case iqd = "IQD"
-		/// Jamaican Dollars (JMD).
-			case jmd = "JMD"
-		/// Japanese Yen (JPY).
-			case jpy = "JPY"
+		/// Iranian Rial (IRR).
+			case irr = "IRR"
+		/// Icelandic Kronur (ISK).
+			case isk = "ISK"
 		/// Jersey Pound.
 			case jep = "JEP"
+		/// Jamaican Dollars (JMD).
+			case jmd = "JMD"
 		/// Jordanian Dinar (JOD).
 			case jod = "JOD"
-		/// Kazakhstani Tenge (KZT).
-			case kzt = "KZT"
+		/// Japanese Yen (JPY).
+			case jpy = "JPY"
 		/// Kenyan Shilling (KES).
 			case kes = "KES"
-		/// Kuwaiti Dinar (KWD).
-			case kwd = "KWD"
 		/// Kyrgyzstani Som (KGS).
 			case kgs = "KGS"
+		/// Cambodian Riel.
+			case khr = "KHR"
+		/// Comorian Franc (KMF).
+			case kmf = "KMF"
+		/// South Korean Won (KRW).
+			case krw = "KRW"
+		/// Kuwaiti Dinar (KWD).
+			case kwd = "KWD"
+		/// Cayman Dollars (KYD).
+			case kyd = "KYD"
+		/// Kazakhstani Tenge (KZT).
+			case kzt = "KZT"
 		/// Laotian Kip (LAK).
 			case lak = "LAK"
-		/// Latvian Lati (LVL).
-			case lvl = "LVL"
 		/// Lebanese Pounds (LBP).
 			case lbp = "LBP"
-		/// Lesotho Loti (LSL).
-			case lsl = "LSL"
+		/// Sri Lankan Rupees (LKR).
+			case lkr = "LKR"
 		/// Liberian Dollar (LRD).
 			case lrd = "LRD"
-		/// Libyan Dinar (LYD).
-			case lyd = "LYD"
+		/// Lesotho Loti (LSL).
+			case lsl = "LSL"
 		/// Lithuanian Litai (LTL).
 			case ltl = "LTL"
+		/// Latvian Lati (LVL).
+			case lvl = "LVL"
+		/// Libyan Dinar (LYD).
+			case lyd = "LYD"
+		/// Moroccan Dirham.
+			case mad = "MAD"
+		/// Moldovan Leu (MDL).
+			case mdl = "MDL"
 		/// Malagasy Ariary (MGA).
 			case mga = "MGA"
 		/// Macedonia Denar (MKD).
 			case mkd = "MKD"
+		/// Burmese Kyat (MMK).
+			case mmk = "MMK"
+		/// Mongolian Tugrik.
+			case mnt = "MNT"
 		/// Macanese Pataca (MOP).
 			case mop = "MOP"
-		/// Malawian Kwacha (MWK).
-			case mwk = "MWK"
+		/// Mauritian Rupee (MUR).
+			case mur = "MUR"
 		/// Maldivian Rufiyaa (MVR).
 			case mvr = "MVR"
+		/// Malawian Kwacha (MWK).
+			case mwk = "MWK"
 		/// Mexican Pesos (MXN).
 			case mxn = "MXN"
 		/// Malaysian Ringgits (MYR).
 			case myr = "MYR"
-		/// Mauritian Rupee (MUR).
-			case mur = "MUR"
-		/// Moldovan Leu (MDL).
-			case mdl = "MDL"
-		/// Moroccan Dirham.
-			case mad = "MAD"
-		/// Mongolian Tugrik.
-			case mnt = "MNT"
 		/// Mozambican Metical.
 			case mzn = "MZN"
 		/// Namibian Dollar.
 			case nad = "NAD"
-		/// Nepalese Rupee (NPR).
-			case npr = "NPR"
-		/// Netherlands Antillean Guilder.
-			case ang = "ANG"
-		/// New Zealand Dollars (NZD).
-			case nzd = "NZD"
-		/// Nicaraguan Córdoba (NIO).
-			case nio = "NIO"
 		/// Nigerian Naira (NGN).
 			case ngn = "NGN"
+		/// Nicaraguan Córdoba (NIO).
+			case nio = "NIO"
 		/// Norwegian Kroner (NOK).
 			case nok = "NOK"
+		/// Nepalese Rupee (NPR).
+			case npr = "NPR"
+		/// New Zealand Dollars (NZD).
+			case nzd = "NZD"
 		/// Omani Rial (OMR).
 			case omr = "OMR"
 		/// Panamian Balboa (PAB).
 			case pab = "PAB"
-		/// Pakistani Rupee (PKR).
-			case pkr = "PKR"
-		/// Papua New Guinean Kina (PGK).
-			case pgk = "PGK"
-		/// Paraguayan Guarani (PYG).
-			case pyg = "PYG"
 		/// Peruvian Nuevo Sol (PEN).
 			case pen = "PEN"
+		/// Papua New Guinean Kina (PGK).
+			case pgk = "PGK"
 		/// Philippine Peso (PHP).
 			case php = "PHP"
+		/// Pakistani Rupee (PKR).
+			case pkr = "PKR"
 		/// Polish Zlotych (PLN).
 			case pln = "PLN"
+		/// Paraguayan Guarani (PYG).
+			case pyg = "PYG"
 		/// Qatari Rial (QAR).
 			case qar = "QAR"
 		/// Romanian Lei (RON).
 			case ron = "RON"
+		/// Serbian dinar (RSD).
+			case rsd = "RSD"
 		/// Russian Rubles (RUB).
 			case rub = "RUB"
 		/// Rwandan Franc (RWF).
 			case rwf = "RWF"
-		/// Samoan Tala (WST).
-			case wst = "WST"
-		/// Saint Helena Pounds (SHP).
-			case shp = "SHP"
 		/// Saudi Riyal (SAR).
 			case sar = "SAR"
-		/// Sao Tome And Principe Dobra (STD).
-			case std = "STD"
-		/// Serbian dinar (RSD).
-			case rsd = "RSD"
-		/// Seychellois Rupee (SCR).
-			case scr = "SCR"
-		/// Sierra Leonean Leone (SLL).
-			case sll = "SLL"
-		/// Singapore Dollars (SGD).
-			case sgd = "SGD"
-		/// Sudanese Pound (SDG).
-			case sdg = "SDG"
-		/// Syrian Pound (SYP).
-			case syp = "SYP"
-		/// South African Rand (ZAR).
-			case zar = "ZAR"
-		/// South Korean Won (KRW).
-			case krw = "KRW"
-		/// South Sudanese Pound (SSP).
-			case ssp = "SSP"
 		/// Solomon Islands Dollar (SBD).
 			case sbd = "SBD"
-		/// Sri Lankan Rupees (LKR).
-			case lkr = "LKR"
-		/// Surinamese Dollar (SRD).
-			case srd = "SRD"
-		/// Swazi Lilangeni (SZL).
-			case szl = "SZL"
+		/// Seychellois Rupee (SCR).
+			case scr = "SCR"
+		/// Sudanese Pound (SDG).
+			case sdg = "SDG"
 		/// Swedish Kronor (SEK).
 			case sek = "SEK"
-		/// Swiss Francs (CHF).
-			case chf = "CHF"
-		/// Taiwan Dollars (TWD).
-			case twd = "TWD"
+		/// Singapore Dollars (SGD).
+			case sgd = "SGD"
+		/// Saint Helena Pounds (SHP).
+			case shp = "SHP"
+		/// Sierra Leonean Leone (SLL).
+			case sll = "SLL"
+		/// Surinamese Dollar (SRD).
+			case srd = "SRD"
+		/// South Sudanese Pound (SSP).
+			case ssp = "SSP"
+		/// Sao Tome And Principe Dobra (STD).
+			case std = "STD"
+		/// Syrian Pound (SYP).
+			case syp = "SYP"
+		/// Swazi Lilangeni (SZL).
+			case szl = "SZL"
 		/// Thai baht (THB).
 			case thb = "THB"
 		/// Tajikistani Somoni (TJS).
 			case tjs = "TJS"
-		/// Tanzanian Shilling (TZS).
-			case tzs = "TZS"
-		/// Tongan Pa'anga (TOP).
-			case top = "TOP"
-		/// Trinidad and Tobago Dollars (TTD).
-			case ttd = "TTD"
-		/// Tunisian Dinar (TND).
-			case tnd = "TND"
-		/// Turkish Lira (TRY).
-			case `try` = "TRY"
 		/// Turkmenistani Manat (TMT).
 			case tmt = "TMT"
-		/// Ugandan Shilling (UGX).
-			case ugx = "UGX"
+		/// Tunisian Dinar (TND).
+			case tnd = "TND"
+		/// Tongan Pa'anga (TOP).
+			case top = "TOP"
+		/// Turkish Lira (TRY).
+			case `try` = "TRY"
+		/// Trinidad and Tobago Dollars (TTD).
+			case ttd = "TTD"
+		/// Taiwan Dollars (TWD).
+			case twd = "TWD"
+		/// Tanzanian Shilling (TZS).
+			case tzs = "TZS"
 		/// Ukrainian Hryvnia (UAH).
 			case uah = "UAH"
-		/// United Arab Emirates Dirham (AED).
-			case aed = "AED"
+		/// Ugandan Shilling (UGX).
+			case ugx = "UGX"
+		/// United States Dollars (USD).
+			case usd = "USD"
 		/// Uruguayan Pesos (UYU).
 			case uyu = "UYU"
 		/// Uzbekistan som (UZS).
 			case uzs = "UZS"
-		/// Vanuatu Vatu (VUV).
-			case vuv = "VUV"
 		/// Venezuelan Bolivares (VEF).
 			case vef = "VEF"
 		/// Vietnamese đồng (VND).
 			case vnd = "VND"
+		/// Vanuatu Vatu (VUV).
+			case vuv = "VUV"
+		/// Samoan Tala (WST).
+			case wst = "WST"
+		/// Central African CFA Franc (XAF).
+			case xaf = "XAF"
+		/// East Caribbean Dollar (XCD).
+			case xcd = "XCD"
 		/// West African CFA franc (XOF).
 			case xof = "XOF"
+		/// CFP Franc (XPF).
+			case xpf = "XPF"
 		/// Yemeni Rial (YER).
 			case yer = "YER"
+		/// South African Rand (ZAR).
+			case zar = "ZAR"
 		/// Zambian Kwacha (ZMW).
 			case zmw = "ZMW"
 		case unknownValue = ""

--- a/Tests/Resources/ExpectedSwiftCode/Enums/CustomerMarketingOptInLevelNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Enums/CustomerMarketingOptInLevelNext.swift
@@ -3,12 +3,12 @@ import Foundation
 
 public extension MerchantApi {
 	enum CustomerMarketingOptInLevel: String, Codable {
-		/// The customer started receiving marketing email(s) after providing their email address, without any
-		/// intermediate steps.
-			case singleOptIn = "SINGLE_OPT_IN"
 		/// After providing their email address, the customer received a confirmation email which required them to
 		/// perform a prescribed action before receiving marketing emails.
 			case confirmedOptIn = "CONFIRMED_OPT_IN"
+		/// The customer started receiving marketing email(s) after providing their email address, without any
+		/// intermediate steps.
+			case singleOptIn = "SINGLE_OPT_IN"
 		/// The customer receives marketing emails, but the original opt-in process is unknown.
 			case unknown = "UNKNOWN"
 		case unknownValue = ""

--- a/Tests/Resources/ExpectedSwiftCode/Enums/MetafieldValueTypeNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Enums/MetafieldValueTypeNext.swift
@@ -3,12 +3,12 @@ import Foundation
 
 public extension MerchantApi {
 	enum MetafieldValueType: String, Codable {
-		/// A string.
-			case string = "STRING"
 		/// An integer.
 			case integer = "INTEGER"
 		/// A JSON string.
 			case jsonString = "JSON_STRING"
+		/// A string.
+			case string = "STRING"
 		case unknownValue = ""
 
 		public init(from decoder: Decoder) throws {

--- a/Tests/Resources/ExpectedSwiftCode/Enums/PrivateMetafieldValueTypeNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Enums/PrivateMetafieldValueTypeNext.swift
@@ -4,11 +4,11 @@ import Foundation
 public extension MerchantApi {
 	enum PrivateMetafieldValueType: String, Codable {
 		/// A private metafield value type.
-			case string = "STRING"
-		/// A private metafield value type.
 			case integer = "INTEGER"
 		/// A private metafield value type.
 			case jsonString = "JSON_STRING"
+		/// A private metafield value type.
+			case string = "STRING"
 		case unknownValue = ""
 
 		public init(from decoder: Decoder) throws {

--- a/Tests/Resources/ExpectedSwiftCode/Enums/TaxExemptionNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Enums/TaxExemptionNext.swift
@@ -3,46 +3,46 @@ import Foundation
 
 public extension MerchantApi {
 	enum TaxExemption: String, Codable {
-		/// This customer is exempt from specific taxes for holding a valid STATUS_CARD_EXEMPTION in Canada.
-			case caStatusCardExemption = "CA_STATUS_CARD_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid RESELLER_EXEMPTION in British Columbia.
-			case caBcResellerExemption = "CA_BC_RESELLER_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid RESELLER_EXEMPTION in Manitoba.
-			case caMbResellerExemption = "CA_MB_RESELLER_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid RESELLER_EXEMPTION in Saskatchewan.
-			case caSkResellerExemption = "CA_SK_RESELLER_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid DIPLOMAT_EXEMPTION in Canada.
-			case caDiplomatExemption = "CA_DIPLOMAT_EXEMPTION"
 		/// This customer is exempt from specific taxes for holding a valid COMMERCIAL_FISHERY_EXEMPTION in British Columbia.
 			case caBcCommercialFisheryExemption = "CA_BC_COMMERCIAL_FISHERY_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid CONTRACTOR_EXEMPTION in British Columbia.
+			case caBcContractorExemption = "CA_BC_CONTRACTOR_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid PRODUCTION_AND_MACHINERY_EXEMPTION in British Columbia.
+			case caBcProductionAndMachineryExemption = "CA_BC_PRODUCTION_AND_MACHINERY_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid RESELLER_EXEMPTION in British Columbia.
+			case caBcResellerExemption = "CA_BC_RESELLER_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid SUB_CONTRACTOR_EXEMPTION in British Columbia.
+			case caBcSubContractorExemption = "CA_BC_SUB_CONTRACTOR_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid DIPLOMAT_EXEMPTION in Canada.
+			case caDiplomatExemption = "CA_DIPLOMAT_EXEMPTION"
 		/// This customer is exempt from specific taxes for holding a valid COMMERCIAL_FISHERY_EXEMPTION in Manitoba.
 			case caMbCommercialFisheryExemption = "CA_MB_COMMERCIAL_FISHERY_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Manitoba.
+			case caMbFarmerExemption = "CA_MB_FARMER_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid RESELLER_EXEMPTION in Manitoba.
+			case caMbResellerExemption = "CA_MB_RESELLER_EXEMPTION"
 		/// This customer is exempt from specific taxes for holding a valid COMMERCIAL_FISHERY_EXEMPTION in Nova Scotia.
 			case caNsCommercialFisheryExemption = "CA_NS_COMMERCIAL_FISHERY_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Nova Scotia.
+			case caNsFarmerExemption = "CA_NS_FARMER_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid PURCHASE_EXEMPTION in Ontario.
+			case caOnPurchaseExemption = "CA_ON_PURCHASE_EXEMPTION"
 		/// This customer is exempt from specific taxes for holding a valid COMMERCIAL_FISHERY_EXEMPTION in Prince Edward Island.
 			case caPeCommercialFisheryExemption = "CA_PE_COMMERCIAL_FISHERY_EXEMPTION"
 		/// This customer is exempt from specific taxes for holding a valid COMMERCIAL_FISHERY_EXEMPTION in Saskatchewan.
 			case caSkCommercialFisheryExemption = "CA_SK_COMMERCIAL_FISHERY_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid PRODUCTION_AND_MACHINERY_EXEMPTION in British Columbia.
-			case caBcProductionAndMachineryExemption = "CA_BC_PRODUCTION_AND_MACHINERY_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid PRODUCTION_AND_MACHINERY_EXEMPTION in Saskatchewan.
-			case caSkProductionAndMachineryExemption = "CA_SK_PRODUCTION_AND_MACHINERY_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid SUB_CONTRACTOR_EXEMPTION in British Columbia.
-			case caBcSubContractorExemption = "CA_BC_SUB_CONTRACTOR_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid SUB_CONTRACTOR_EXEMPTION in Saskatchewan.
-			case caSkSubContractorExemption = "CA_SK_SUB_CONTRACTOR_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid CONTRACTOR_EXEMPTION in British Columbia.
-			case caBcContractorExemption = "CA_BC_CONTRACTOR_EXEMPTION"
 		/// This customer is exempt from specific taxes for holding a valid CONTRACTOR_EXEMPTION in Saskatchewan.
 			case caSkContractorExemption = "CA_SK_CONTRACTOR_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid PURCHASE_EXEMPTION in Ontario.
-			case caOnPurchaseExemption = "CA_ON_PURCHASE_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Manitoba.
-			case caMbFarmerExemption = "CA_MB_FARMER_EXEMPTION"
-		/// This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Nova Scotia.
-			case caNsFarmerExemption = "CA_NS_FARMER_EXEMPTION"
 		/// This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Saskatchewan.
 			case caSkFarmerExemption = "CA_SK_FARMER_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid PRODUCTION_AND_MACHINERY_EXEMPTION in Saskatchewan.
+			case caSkProductionAndMachineryExemption = "CA_SK_PRODUCTION_AND_MACHINERY_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid RESELLER_EXEMPTION in Saskatchewan.
+			case caSkResellerExemption = "CA_SK_RESELLER_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid SUB_CONTRACTOR_EXEMPTION in Saskatchewan.
+			case caSkSubContractorExemption = "CA_SK_SUB_CONTRACTOR_EXEMPTION"
+		/// This customer is exempt from specific taxes for holding a valid STATUS_CARD_EXEMPTION in Canada.
+			case caStatusCardExemption = "CA_STATUS_CARD_EXEMPTION"
 		case unknownValue = ""
 
 		public init(from decoder: Decoder) throws {


### PR DESCRIPTION
## Description of issue and change

Enum type generation can lead to noise by changing the order of enums.  This PR addresses that issue by enforcing a sorted order based on Swift's String sort.  The change was accomplished by modifying the renderer's context to provide the necessary sorted array of values, as there is no current mechanism to sort using Stencil.