### PR TITLE
Set up support for the subscription operation type

### DIFF
--- a/Sources/SyrupCore/Generator/Swift/SwiftRenderer.swift
+++ b/Sources/SyrupCore/Generator/Swift/SwiftRenderer.swift
@@ -99,6 +99,12 @@ final class SwiftRenderer: Renderer {
 		renderedMutation += try renderQuerySelections(mutationSelections, enabled: config.project.generateSelections)
 		return renderedMutation
 	}
+    
+	override func renderSubscription(subscription: IntermediateRepresentation.OperationDefinition, intermediateRepresentation: IntermediateRepresentation, subscriptionSelections: SelectionSetVisitor.Operation) throws -> String {
+		var renderedSubscription = try super.renderSubscription(subscription: subscription, intermediateRepresentation: intermediateRepresentation, subscriptionSelections: subscriptionSelections)
+		renderedSubscription += try renderQuerySelections(subscriptionSelections, enabled: config.project.generateSelections)
+		return renderedSubscription
+	}
 	
 	func renderCustomScalarResolver(customScalars: [IntermediateRepresentation.CustomCodedScalar]) throws -> String {
 		let context: [String: Any] = [
@@ -148,6 +154,8 @@ final class SwiftRenderer: Renderer {
 			operationSuffix = "Query"
 		case .mutation:
 			operationSuffix = "Mutation"
+		case .subscription:
+			operationSuffix = "Subscription"
 		}
 		let context: [String: Any] = ["operation": operation, "suffix": operationSuffix, "enabled": enabled]
 		return try render(template: "OperationSelections", context: context)

--- a/Sources/SyrupCore/GraphQL/OperationVisitor.swift
+++ b/Sources/SyrupCore/GraphQL/OperationVisitor.swift
@@ -36,11 +36,12 @@ final class OperationVisitor: GraphQLBaseVisitor {
 	public var queries: [String: String] = [:]
 	public var mutations: [String: String] = [:]
 	public var fragments: [String: String] = [:]
+	public var subscriptions: [String: String] = [:]
 	
 	private var currentOperationName: String = ""
 	private var currentOperationType: OperationType = .query
 	private enum OperationType: String {
-		case query, mutation, fragment
+		case query, mutation, fragment, subscription
 		
 		init?(rawValue: String) {
 			switch rawValue {
@@ -50,6 +51,8 @@ final class OperationVisitor: GraphQLBaseVisitor {
 				self = .mutation
 			case OperationType.fragment.rawValue:
 				self = .fragment
+			case OperationType.subscription.rawValue:
+				self = .subscription
 			default:
 				return nil
 			}
@@ -123,6 +126,8 @@ final class OperationVisitor: GraphQLBaseVisitor {
 			mutations[currentOperationName] = currentOperationContents
 		case .fragment:
 			fragments[currentOperationName] = currentOperationContents
+		case .subscription:
+			subscriptions[currentOperationName] = currentOperationContents
 		}
 	}
 	

--- a/Sources/SyrupCore/GraphQL/Schema.swift
+++ b/Sources/SyrupCore/GraphQL/Schema.swift
@@ -27,6 +27,7 @@ import Foundation
 struct Schema: Decodable {
 	private let queryTypeName: String
 	private let mutationTypeName: String?
+	private let subscriptionTypeName: String?
 	let types: [SchemaType]
 	let directives: [Directive]
 	
@@ -37,6 +38,11 @@ struct Schema: Decodable {
 	var mutationType: SchemaType? {
 		guard let mutationTypeName = mutationTypeName else { return nil }
 		return self.type(named: mutationTypeName)
+	}
+    
+	var subscriptionType: SchemaType? {
+		guard let subscriptionTypeName = subscriptionTypeName else { return nil }
+		return self.type(named: subscriptionTypeName)
 	}
 	
 	enum DataKey: String, CodingKey {
@@ -50,6 +56,7 @@ struct Schema: Decodable {
 	enum CodingKeys: String, CodingKey {
 		case queryType
 		case mutationType
+		case subscriptionType
 		case types
 		case directives
 	}
@@ -65,6 +72,11 @@ struct Schema: Decodable {
 			mutationTypeName = nil
 		} else {
 			mutationTypeName = try values.nestedContainer(keyedBy: NameKey.self, forKey: .mutationType).decode(String.self, forKey: .name)
+		}
+		if try values.decodeNil(forKey: .subscriptionType) {
+			subscriptionTypeName = nil
+		} else {
+			subscriptionTypeName = try values.nestedContainer(keyedBy: NameKey.self, forKey: .subscriptionType).decode(String.self, forKey: .name)
 		}
 		types = try values.decode([SchemaType].self, forKey: .types)
 		directives = try values.decode([Directive].self, forKey: .directives)

--- a/Sources/SyrupCore/GraphQL/SelectionSetVisitor.swift
+++ b/Sources/SyrupCore/GraphQL/SelectionSetVisitor.swift
@@ -66,6 +66,8 @@ class SelectionSetVisitor: GraphQLBaseVisitor {
 			parentType = schema.queryType
 		case .mutation:
 			parentType = schema.mutationType!
+		case .subscription:
+			parentType = schema.subscriptionType!
 		default:
 			fatalError("Parsing unsupported operation of type \(operation.operationType)")
 		}
@@ -79,6 +81,8 @@ class SelectionSetVisitor: GraphQLBaseVisitor {
 			operationType = .query(schema.queryType.name)
 		case .mutation:
 			operationType = .mutation(schema.mutationType!.name)
+		case .subscription:
+			operationType = .subscription(schema.subscriptionType!.name)
 		default:
 			fatalError("Parsing unsupported operation of type \(operation.operationType)")
 		}
@@ -383,10 +387,11 @@ extension SelectionSetVisitor {
 	enum OperationType {
 		case mutation(String)
 		case query(String)
+		case subscription(String)
 		
 		var name: String {
 			switch self {
-			case .mutation(let name), .query(let name):
+			case .mutation(let name), .query(let name), .subscription(let name):
 				return name
 			}
 		}

--- a/Sources/SyrupCore/GraphQL/SwiftGraphQLParser+Extensions.swift
+++ b/Sources/SyrupCore/GraphQL/SwiftGraphQLParser+Extensions.swift
@@ -25,7 +25,7 @@
 import Foundation
 import SwiftGraphQLParser
 
-func parse(queries: [String], mutations: [String], fragments: [String]) throws -> Document {
-	let graphQLString = [fragments, queries, mutations].flatMap { $0 }.joined(separator: " ")
+func parse(queries: [String], mutations: [String], fragments: [String], subscriptions: [String]) throws -> Document {
+	let graphQLString = [fragments, queries, mutations, subscriptions].flatMap { $0 }.joined(separator: " ")
 	return try parse(graphQLString)
 }

--- a/Sources/SyrupCore/IR/IntermediateRepresentation.swift
+++ b/Sources/SyrupCore/IR/IntermediateRepresentation.swift
@@ -43,11 +43,11 @@ struct IntermediateRepresentation {
 	}
 	
 	enum ParentType: Equatable {
-		case query(String), mutation(String), fragment(String)
+		case query(String), mutation(String), fragment(String), subscription(String)
 		
 		var name: String {
 			switch self {
-			case .query(let name), .mutation(let name), .fragment(let name):
+			case .query(let name), .mutation(let name), .fragment(let name), .subscription(let name):
 				return name
 			}
 		}
@@ -59,6 +59,8 @@ struct IntermediateRepresentation {
 			case (.mutation(let lhsName), .mutation(let rhsName)):
 				return lhsName == rhsName
 			case (.fragment(let lhsName), .fragment(let rhsName)):
+				return lhsName == rhsName
+			case (.subscription(let lhsName), .subscription(let rhsName)):
 				return lhsName == rhsName
 			default:
 				return false
@@ -222,7 +224,7 @@ struct IntermediateRepresentation {
 	}
 	
 	enum OperationType {
-		case query, mutation
+		case query, mutation, subscription
 	}
 	
 	struct FragmentDefinition: NamedItem {
@@ -377,6 +379,16 @@ extension Array where Element == IntermediateRepresentation.OperationDefinition 
 	var queries: [IntermediateRepresentation.OperationDefinition] {
 		return filter {
 			if case .query = $0.type {
+				return true
+			} else {
+				return false
+			}
+		}
+	}
+    
+	var subscriptions: [IntermediateRepresentation.OperationDefinition] {
+		return filter {
+			if case .subscription = $0.type {
 				return true
 			} else {
 				return false

--- a/Sources/SyrupCore/Reporter/Reporter.swift
+++ b/Sources/SyrupCore/Reporter/Reporter.swift
@@ -59,7 +59,8 @@ public final class Reporter {
 				builtInScalars: config.template.specification.builtInScalars,
 				queries: opsVisitor.queries,
 				mutations: opsVisitor.mutations,
-				fragments: opsVisitor.fragments
+				fragments: opsVisitor.fragments,
+				subscriptions: opsVisitor.subscriptions
 		)
 
 		let irTraverser = GraphQLTraverser(document: document, with: irVisitor)

--- a/Sources/SyrupCore/Stencil Extensions/SelectionSetExtension.swift
+++ b/Sources/SyrupCore/Stencil Extensions/SelectionSetExtension.swift
@@ -68,6 +68,8 @@ class SelectionSetExtension: Extension {
 			return ".mutation(\"\(mutationType)\")"
 		case .query(let queryType):
 			return ".query(\"\(queryType)\")"
+		case .subscription(let subscriptionType):
+			return ".subscription(\"\(subscriptionType)\")"
 		}
 	}
 	


### PR DESCRIPTION
⚠️  Using `subscriptions` as a feature branch, as I'd like to get code review through the process of getting this support in.

### ✍️  Description of change
This PR adds support for handling subscriptions as an operation type to the core of Syrup. Stencils and tests are up next. This is part of supporting #19 

The general approach here was made with the assumption that Syrup should handle the `subscription` operation very similarly to how it handles the `query` and `mutation` operations. There isn't much in here that is actually subscription-specific, just handling it as an additional operation type.

### 👀 and 🎩 

- Running with these changes won't give us usable output yet, but can test that this does run on a schema that includes subscriptions.
- Going to comment on specific areas of review focus (Swift Is Weird)