### PR TITLE
Update templates to handle the subscription operation type

### DIFF
--- a/Sources/SyrupCore/Generator/Renderer.swift
+++ b/Sources/SyrupCore/Generator/Renderer.swift
@@ -136,27 +136,27 @@ open class Renderer {
         return rendered
     }
     
-    func renderSubscription(subscription: IntermediateRepresentation.OperationDefinition, intermediateRepresentation: IntermediateRepresentation, subscriptionSelections: SelectionSetVisitor.Operation) throws -> String {
-        let name = "\(subscription.name)Subscription"
-        let queryString = intermediateRepresentation.fullQueryString(for: subscription).removingLeadingSpaces.removingNewLines
-        let importEnums = intermediateRepresentation.referencedEnums.isEmpty == false
-        let importInputs = intermediateRepresentation.referencedInputTypes.isEmpty == false
-        let importFragments = intermediateRepresentation.fragmentDefinitions.isEmpty == false
-        let requiresCustomEncoder = subscription.variables.contains(where: { $0.type.nestedScalar() is IntermediateRepresentation.CustomCodedScalar })
-        let context: [String: Any] = [
-            "name": name,
-            "operation": subscription,
-            "queryString": queryString,
-            "moduleName": config.project.moduleName,
-            "isQuery": true,
-            "importEnums": importEnums,
-            "importInputs": importInputs,
-            "importFragments": importFragments,
-            "requiresCustomEncoder": requiresCustomEncoder,
-            "selections": subscriptionSelections.selectionSet
-        ]
-        return try render(template: "Operation", asFile: true, context: context)
-    }
+	func renderSubscription(subscription: IntermediateRepresentation.OperationDefinition, intermediateRepresentation: IntermediateRepresentation, subscriptionSelections: SelectionSetVisitor.Operation) throws -> String {
+		let name = "\(subscription.name)Subscription"
+		let queryString = intermediateRepresentation.fullQueryString(for: subscription).removingLeadingSpaces.removingNewLines
+		let importEnums = intermediateRepresentation.referencedEnums.isEmpty == false
+		let importInputs = intermediateRepresentation.referencedInputTypes.isEmpty == false
+		let importFragments = intermediateRepresentation.fragmentDefinitions.isEmpty == false
+		let requiresCustomEncoder = subscription.variables.contains(where: { $0.type.nestedScalar() is IntermediateRepresentation.CustomCodedScalar })
+		let context: [String: Any] = [
+			"name": name,
+			"operation": subscription,
+			"queryString": queryString,
+			"moduleName": config.project.moduleName,
+			"isQuery": false,
+			"importEnums": importEnums,
+			"importInputs": importInputs,
+			"importFragments": importFragments,
+			"requiresCustomEncoder": requiresCustomEncoder,
+			"selections": subscriptionSelections.selectionSet
+		]
+		return try render(template: "Operation", asFile: true, context: context)
+	}
 
 	func renderEnumTypes(intermediateRepresentation: IntermediateRepresentation) throws -> [String] {
 		var rendered: [String] = []

--- a/Sources/SyrupCore/GraphQL/IntermediateRepresentationVisitor.swift
+++ b/Sources/SyrupCore/GraphQL/IntermediateRepresentationVisitor.swift
@@ -75,13 +75,18 @@ class IntermediateRepresentationVisitor: GraphQLBaseVisitor {
 	}
 	
 	override func visitOperation(operation: SwiftGraphQLParser.Operation) throws {
-		if operation.operationType == .query {
-			parentType.push(schema.queryType)
-		} else if let mutationType = schema.mutationType {
-			parentType.push(mutationType)
-		} else {
+		let schemaType: Schema.SchemaType
+		switch operation.operationType {
+		case .query:
+			schemaType = schema.queryType
+		case .mutation:
+			schemaType = schema.mutationType!
+		case .subscription:
+			schemaType = schema.subscriptionType!
+		default:
 			throw Error(description: "Cannot create operation type of \(operation.operationType)")
 		}
+		parentType.push(schemaType)
 	}
 	
 	override func exitOperation(operation: SwiftGraphQLParser.Operation) {

--- a/Templates/Kotlin/GraphApi.stencil
+++ b/Templates/Kotlin/GraphApi.stencil
@@ -37,6 +37,8 @@ interface Query<T : Response> : SyrupOperation<T>
 
 interface Mutation<T : Response> : SyrupOperation<T>
 
+interface Subscription<T : Response> : SyrupOperation<T>
+
 interface Response
 
 object OperationGsonBuilder {

--- a/Templates/Kotlin/Operation.stencil
+++ b/Templates/Kotlin/Operation.stencil
@@ -1,5 +1,5 @@
 {% if asFile %}
-package {% if moduleName %}{{ moduleName }}{% else %}com.shopify.syrup{% endif %}.{% if isQuery %}queries{% else %}mutations{% endif %}
+package {% if moduleName %}{{ moduleName }}{% else %}com.shopify.syrup{% endif %}.{% if isQuery %}queries{% else %}{{ operation.typeName|lowercase }}s{% endif %}
 
 {{ header }}
 import com.google.gson.*
@@ -13,7 +13,7 @@ import javax.annotation.Generated
 
 @Generated("{% if moduleName %}{{ moduleName }}{% else %}com.shopify.syrup{% endif %}")
 {% endif %}
-class {{ name }}({{ operation.variables|renderKotlinArguments }}): {% if isQuery %}Query{% else %}Mutation{% endif %}<{{ operation.name }}Response> {
+class {{ name }}({{ operation.variables|renderKotlinArguments }}): {% if isQuery %}Query{% else %}{{ operation.typeName }}{% endif %}<{{ operation.name }}Response> {
 
     override val rawQueryString = "{{ queryString|replace:"$","\$"|replaceQuotes }}"
 
@@ -22,8 +22,8 @@ class {{ name }}({{ operation.variables|renderKotlinArguments }}): {% if isQuery
     }
 
     override val operationVariables = mapOf<String, String>(
-        {{ operation.variables|renderKotlinOperationVariables }}
+        {% if operation.typeName != "Subscription" %}{{ operation.variables|renderKotlinOperationVariables }}{% endif %}
     )
 
-    override val selections = {{ selections|renderKotlinSelections }}
+    override val selections = {% if operation.typeName != "Subscription" %}{{ selections|renderKotlinSelections }}{% else %}listOf<Selection>(){% endif %}
 }

--- a/Templates/Swift/GraphApi.stencil
+++ b/Templates/Swift/GraphApi.stencil
@@ -150,9 +150,10 @@ public enum GraphSelections {
 	public enum OperationType {
 		case mutation(String)
 		case query(String)
+		case subscription(String)
 		public var name: String {
 			switch self {
-			case .mutation(let name), .query(let name):
+			case .mutation(let name), .query(let name), .subscription(let name):
 				return name
 			}
 		}

--- a/Tests/Resources/ExpectedKotlinCode/GraphApi.kt
+++ b/Tests/Resources/ExpectedKotlinCode/GraphApi.kt
@@ -37,6 +37,8 @@ interface Query<T : Response> : SyrupOperation<T>
 
 interface Mutation<T : Response> : SyrupOperation<T>
 
+interface Subscription<T : Response> : SyrupOperation<T>
+
 interface Response
 
 object OperationGsonBuilder {

--- a/Tests/Resources/ExpectedSwiftCode/GraphApi.swift
+++ b/Tests/Resources/ExpectedSwiftCode/GraphApi.swift
@@ -151,9 +151,10 @@ public enum GraphSelections {
 	public enum OperationType {
 		case mutation(String)
 		case query(String)
+		case subscription(String)
 		public var name: String {
 			switch self {
-			case .mutation(let name), .query(let name):
+			case .mutation(let name), .query(let name), .subscription(let name):
 				return name
 			}
 		}


### PR DESCRIPTION
⚠️  Using `subscriptions` as a feature branch, as I'd like to get code review through the process of getting this support in.

### ✍️  Description of change
This PR adds support for the subscription operation type into Syrup's Stencil templates. This is part of supporting #19 

Not too much needed to be done here - we determined that the `Operation` template was already pretty sufficient, so the changes here are really just to make sure the right operation type is outputted.

The original plan was to get rid of the `isQuery` context variable, but after doing this I see why it was introduced in the first place. Without it we need to put conditional Stencil logic checking for both "Query" and "QueryRoot" types. So, I left it in.

Subscription tests are next up. 🦀 

### 👀 and 🎩 

Special 👀 appreciated on the Swift Template changes since I do not regularly work in Swift.

- Current `query` and `mutation` generated files should not change at all.
- If you have any `subscription`-supporting schemas to test on, subscription graphQL should generate proper files as well at this point.