### PR TITLE
Generate Subscription types

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/JohnSundell/files",
         "state": {
           "branch": null,
-          "revision": "22fe84797d499ffca911ccd896b34efaf06a50b9",
-          "version": "4.1.1"
+          "revision": "6568bfe636f02dfd85dc9d51b3782555b83080d3",
+          "version": "4.0.2"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/Shopify/SwiftGraphQLParser",
         "state": {
           "branch": null,
-          "revision": "0fcadd4bf9a348c6af97fed05d1c25302e86e1ec",
-          "version": "0.1.7"
+          "revision": "2be6c11a6074140af4f02cbea916739d9d6a8a29",
+          "version": "0.1.8"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
 		),
 		.package(
 			url: "https://github.com/Shopify/SwiftGraphQLParser",
-			from: "0.1.7"
+			from: "0.1.8"
 		)
 	],
 	targets: [

--- a/Sources/SyrupCore/Generator/Generator.swift
+++ b/Sources/SyrupCore/Generator/Generator.swift
@@ -45,8 +45,8 @@ public final class Generator {
 				return "\(result)\n\(operation)"
 			}
 			let operations = try Generator.parseOperations(graphQLString: graphQLString)
-			let selectionSets = try generateSelectionSets(schema: schema, queries: operations.queries, mutations: operations.mutations, fragments: operations.fragments)
-			let ir = try generateIntermediateRepresentation(schema: schema, customScalars: config.schema.customScalars, queries: operations.queries, mutations: operations.mutations, fragments: operations.fragments)
+			let selectionSets = try generateSelectionSets(schema: schema, queries: operations.queries, mutations: operations.mutations, subscriptions: operations.subscriptions, fragments: operations.fragments)
+			let ir = try generateIntermediateRepresentation(schema: schema, customScalars: config.schema.customScalars, queries: operations.queries, mutations: operations.mutations, subscriptions: operations.subscriptions, fragments: operations.fragments)
 			let generatedFiles: [File]
 			switch config.template.specification.language {
 			case .swift:
@@ -89,6 +89,7 @@ public final class Generator {
 		case response
 		case fragment
 		case mutation
+		case subscription
 		case input
 		case `enum`
 
@@ -102,6 +103,8 @@ public final class Generator {
 				return "Fragments"
 			case .mutation:
 				return "Mutations"
+			case .subscription:
+				return "Subscriptions"
 			case .input:
 				return "Inputs"
 			case .enum:
@@ -117,6 +120,8 @@ public final class Generator {
 				return "Response"
 			case .mutation:
 				return "Mutation"
+			case .subscription:
+				return "Subscription"
 			case .fragment, .input, .enum:
 				return ""
 			}
@@ -142,26 +147,26 @@ public final class Generator {
 		}
 	}
 
-	public static func parseOperations(graphQLString: String) throws -> (queries: [String: String], mutations: [String: String], fragments: [String: String]) {
+	public static func parseOperations(graphQLString: String) throws -> (queries: [String: String], mutations: [String: String], subscriptions: [String: String], fragments: [String: String]) {
 		print("Parsing .graphql files")
 		let visitor = OperationVisitor()
 		let document = try parse(graphQLString)
 		let traverser = GraphQLTraverser(document: document, with: visitor)
 		try traverser.traverse()
-		return (visitor.queries, visitor.mutations, visitor.fragments)
+		return (visitor.queries, visitor.mutations, visitor.subscriptions, visitor.fragments)
 	}
 
-	func generateIntermediateRepresentation(schema: Schema, customScalars: [ScalarType], queries: [String: String], mutations: [String: String], fragments: [String: String]) throws -> IntermediateRepresentation {
-		let visitor = IntermediateRepresentationVisitor(schema: schema, customScalars: customScalars, builtInScalars: config.template.specification.builtInScalars, queries: queries, mutations: mutations, fragments: fragments)
-		let document = try parse(queries: queries.map { $0.value }, mutations: mutations.map { $0.value }, fragments: fragments.map { $0.value })
+	func generateIntermediateRepresentation(schema: Schema, customScalars: [ScalarType], queries: [String: String], mutations: [String: String], subscriptions: [String: String], fragments: [String: String]) throws -> IntermediateRepresentation {
+		let visitor = IntermediateRepresentationVisitor(schema: schema, customScalars: customScalars, builtInScalars: config.template.specification.builtInScalars, queries: queries, mutations: mutations, subscriptions: subscriptions, fragments: fragments)
+		let document = try parse(queries: queries.map { $0.value }, mutations: mutations.map { $0.value }, subscriptions: subscriptions.map { $0.value }, fragments: fragments.map { $0.value })
 		let traverser = GraphQLTraverser(document: document, with: visitor)
 		try traverser.traverse()
 		return visitor.intermediateRepresentation
 	}
 
-	func generateSelectionSets(schema: Schema, queries: [String: String], mutations: [String: String], fragments: [String: String]) throws -> SelectionSetVisitor.Results {
+	func generateSelectionSets(schema: Schema, queries: [String: String], mutations: [String: String], subscriptions: [String: String], fragments: [String: String]) throws -> SelectionSetVisitor.Results {
 		let visitor = SelectionSetVisitor(schema: schema)
-		let document = try parse(queries: queries.map { $0.value }, mutations: mutations.map { $0.value }, fragments: fragments.map { $0.value })
+		let document = try parse(queries: queries.map { $0.value }, mutations: mutations.map { $0.value }, subscriptions: subscriptions.map { $0.value }, fragments: fragments.map { $0.value })
 		let traverser = GraphQLTraverser(document: document, with: visitor)
 		try traverser.traverse()
 		return visitor.results
@@ -206,7 +211,7 @@ public final class Generator {
 			let renderer = KotlinRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.queries }, fileType: .query, renderer: { (ir) -> [String] in
-				return try renderer.renderQueries(intermediateRepresentation: ir, selectionSets: selectionSets)
+				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.queries)
 			})
 		}
 		
@@ -214,7 +219,7 @@ public final class Generator {
 			let renderer = KotlinRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.mutations }, fileType: .mutation, renderer: { (ir) -> [String] in
-				return try renderer.renderMutations(intermediateRepresentation: ir, selectionSets: selectionSets)
+				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations:  ir.operations.mutations)
 			})
 		}
 		
@@ -229,6 +234,14 @@ public final class Generator {
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.fragmentDefinitions }, fileType: .fragment, renderer: { (ir) -> [String] in
 				return try renderer.renderFragmentDefinitions(intermediateRepresentation: ir, selectionSets: selectionSets)
+			})
+		}
+        
+		concurrentPerform {
+			let renderer = KotlinRenderer(config: self.config)
+			
+			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.subscriptions }, fileType: .subscription, renderer: { (ir) -> [String] in
+				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.subscriptions)
 			})
 		}
 		
@@ -295,7 +308,7 @@ public final class Generator {
 			let renderer = SwiftRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.queries }, fileType: .query, renderer: { (ir) -> [String] in
-				return try renderer.renderQueries(intermediateRepresentation: ir, selectionSets: selectionSets)
+				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations:  ir.operations.queries)
 			})
 		}
 		
@@ -303,13 +316,21 @@ public final class Generator {
 			let renderer = SwiftRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.mutations }, fileType: .mutation, renderer: { (ir) -> [String] in
-				return try renderer.renderMutations(intermediateRepresentation: ir, selectionSets: selectionSets) })
+				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations:  ir.operations.mutations) })
 		}
 		
 		concurrentPerform {
 			let renderer = SwiftRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations }, fileType: .response, renderer: renderer.renderResponseTypes)
+		}
+        
+		concurrentPerform {
+			let renderer = SwiftRenderer(config: self.config)
+			
+			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.subscriptions }, fileType: .subscription, renderer: { (ir) -> [String] in
+				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.subscriptions)
+			})
 		}
 		
 		concurrentPerform {

--- a/Sources/SyrupCore/Generator/Swift/SwiftRenderer.swift
+++ b/Sources/SyrupCore/Generator/Swift/SwiftRenderer.swift
@@ -88,16 +88,10 @@ final class SwiftRenderer: Renderer {
 		return rendered
 	}
 	
-	override func renderQuery(query: IntermediateRepresentation.OperationDefinition, intermediateRepresentation: IntermediateRepresentation, querySelections: SelectionSetVisitor.Operation) throws -> String {
-		var renderedQuery = try super.renderQuery(query: query, intermediateRepresentation: intermediateRepresentation, querySelections: querySelections)
-		renderedQuery += try renderQuerySelections(querySelections, enabled: config.project.generateSelections)
+	override func renderOperation(operation: IntermediateRepresentation.OperationDefinition, intermediateRepresentation: IntermediateRepresentation, operationSelections: SelectionSetVisitor.Operation) throws -> String {
+		var renderedQuery = try super.renderOperation(operation: operation, intermediateRepresentation: intermediateRepresentation, operationSelections: operationSelections)
+		renderedQuery += try renderoperationSelections(operationSelections, enabled: config.project.generateSelections)
 		return renderedQuery
-	}
-	
-	override func renderMutation(mutation: IntermediateRepresentation.OperationDefinition, intermediateRepresentation: IntermediateRepresentation, mutationSelections: SelectionSetVisitor.Operation) throws -> String {
-		var renderedMutation = try super.renderMutation(mutation: mutation, intermediateRepresentation: intermediateRepresentation, mutationSelections: mutationSelections)
-		renderedMutation += try renderQuerySelections(mutationSelections, enabled: config.project.generateSelections)
-		return renderedMutation
 	}
 	
 	func renderCustomScalarResolver(customScalars: [IntermediateRepresentation.CustomCodedScalar]) throws -> String {
@@ -141,13 +135,15 @@ final class SwiftRenderer: Renderer {
 		return try render(template: "FragmentSelections", context: context)
 	}
 	
-	private func renderQuerySelections(_ operation: SelectionSetVisitor.Operation, enabled: Bool) throws -> String {
+	private func renderoperationSelections(_ operation: SelectionSetVisitor.Operation, enabled: Bool) throws -> String {
 		let operationSuffix: String
 		switch operation.type {
 		case .query:
 			operationSuffix = "Query"
 		case .mutation:
 			operationSuffix = "Mutation"
+		case .subscription:
+			operationSuffix = "Subscription"
 		}
 		let context: [String: Any] = ["operation": operation, "suffix": operationSuffix, "enabled": enabled]
 		return try render(template: "OperationSelections", context: context)

--- a/Sources/SyrupCore/GraphQL/IntermediateRepresentationVisitor.swift
+++ b/Sources/SyrupCore/GraphQL/IntermediateRepresentationVisitor.swift
@@ -31,6 +31,7 @@ class IntermediateRepresentationVisitor: GraphQLBaseVisitor {
 	private let queries: [String: String]
 	private let mutations: [String: String]
 	private let fragments: [String: String]
+	private let subscriptions: [String: String]
 
 	private var operations: [IntermediateRepresentation.OperationDefinition] = []
 	private var fragmentDefinitions: [IntermediateRepresentation.FragmentDefinition] = []
@@ -62,43 +63,55 @@ class IntermediateRepresentationVisitor: GraphQLBaseVisitor {
 		}
 	}
 	
-	required init(schema: Schema, customScalars: [ScalarType], builtInScalars: TemplateSpec.BuiltInScalars, queries: [String: String], mutations: [String: String], fragments: [String: String]) {
+	required init(schema: Schema, customScalars: [ScalarType], builtInScalars: TemplateSpec.BuiltInScalars, queries: [String: String], mutations: [String: String], subscriptions: [String: String], fragments: [String: String]) {
 		self.schema = schema
 		self.queries = queries
 		self.mutations = mutations
 		self.fragments = fragments
+		self.subscriptions = subscriptions
 		self.scalars = IntermediateRepresentationVisitor.mergeScalarTypes(customScalars: customScalars, builtInScalars: builtInScalars)
 
 		super.init()
 	}
 	
 	override func visitOperation(operation: SwiftGraphQLParser.Operation) throws {
-		if operation.operationType == .query {
-			parentType.push(schema.queryType)
-		} else if let mutationType = schema.mutationType {
-			parentType.push(mutationType)
-		} else {
+		let schemaType: Schema.SchemaType
+		switch operation.operationType {
+		case .query:
+			schemaType = schema.queryType
+		case .mutation:
+			schemaType = schema.mutationType!
+		case .subscription:
+			schemaType = schema.subscriptionType!
+		default:
 			throw Error(description: "Cannot create operation type of \(operation.operationType)")
 		}
+		parentType.push(schemaType)
 	}
 	
 	override func exitOperation(operation: SwiftGraphQLParser.Operation) {
 		let name = operation.name!
 		let selections = parsedSelections.pop()
 		parentType.pop()
-		let type: IntermediateRepresentation.OperationType = operation.operationType == .query ? .query : .mutation
-		let operation: String
+		let type: IntermediateRepresentation.OperationType
+		let operationString: String
 		let typeName: String
-		switch type {
+		switch operation.operationType {
 		case .query:
-			operation = queries[name]!
+			type = .query
+			operationString = queries[name]!
 			typeName = schema.queryType.name
 		case .mutation:
-			operation = mutations[name]!
+			type = .mutation
+			operationString = mutations[name]!
 			typeName = schema.mutationType!.name
+		case .subscription:
+			type = .subscription
+			operationString = subscriptions[name]!
+			typeName = schema.subscriptionType!.name
 		}
 		let variables = parsedVariables
-		let operationDefinition = IntermediateRepresentation.OperationDefinition(name: name, selections: selections, typeName: typeName, type: type, variables: variables, operation: operation)
+		let operationDefinition = IntermediateRepresentation.OperationDefinition(name: name, selections: selections, typeName: typeName, type: type, variables: variables, operation: operationString)
 		operations.append(operationDefinition)
 		parsedVariables = []
 	}

--- a/Sources/SyrupCore/GraphQL/OperationVisitor.swift
+++ b/Sources/SyrupCore/GraphQL/OperationVisitor.swift
@@ -36,11 +36,12 @@ final class OperationVisitor: GraphQLBaseVisitor {
 	public var queries: [String: String] = [:]
 	public var mutations: [String: String] = [:]
 	public var fragments: [String: String] = [:]
+	public var subscriptions: [String: String] = [:]
 	
 	private var currentOperationName: String = ""
 	private var currentOperationType: OperationType = .query
 	private enum OperationType: String {
-		case query, mutation, fragment
+		case query, mutation, fragment, subscription
 		
 		init?(rawValue: String) {
 			switch rawValue {
@@ -50,6 +51,8 @@ final class OperationVisitor: GraphQLBaseVisitor {
 				self = .mutation
 			case OperationType.fragment.rawValue:
 				self = .fragment
+			case OperationType.subscription.rawValue:
+				self = .subscription
 			default:
 				return nil
 			}
@@ -123,6 +126,8 @@ final class OperationVisitor: GraphQLBaseVisitor {
 			mutations[currentOperationName] = currentOperationContents
 		case .fragment:
 			fragments[currentOperationName] = currentOperationContents
+		case .subscription:
+			subscriptions[currentOperationName] = currentOperationContents
 		}
 	}
 	
@@ -161,7 +166,6 @@ final class OperationVisitor: GraphQLBaseVisitor {
 	
 	override func visitSelectionSet(selectionSet: [SwiftGraphQLParser.Selection]) {
 		currentOperationContents += " {\n"
-		currentOperationContents += "__typename\n"
 	}
 	
 	override func exitSelectionSet(selectionSet: [SwiftGraphQLParser.Selection]) {

--- a/Sources/SyrupCore/GraphQL/Schema.swift
+++ b/Sources/SyrupCore/GraphQL/Schema.swift
@@ -27,6 +27,7 @@ import Foundation
 struct Schema: Decodable {
 	private let queryTypeName: String
 	private let mutationTypeName: String?
+	private let subscriptionTypeName: String?
 	let types: [SchemaType]
 	let directives: [Directive]
 	
@@ -37,6 +38,11 @@ struct Schema: Decodable {
 	var mutationType: SchemaType? {
 		guard let mutationTypeName = mutationTypeName else { return nil }
 		return self.type(named: mutationTypeName)
+	}
+    
+	var subscriptionType: SchemaType? {
+		guard let subscriptionTypeName = subscriptionTypeName else { return nil }
+		return self.type(named: subscriptionTypeName)
 	}
 	
 	enum DataKey: String, CodingKey {
@@ -50,6 +56,7 @@ struct Schema: Decodable {
 	enum CodingKeys: String, CodingKey {
 		case queryType
 		case mutationType
+		case subscriptionType
 		case types
 		case directives
 	}
@@ -65,6 +72,11 @@ struct Schema: Decodable {
 			mutationTypeName = nil
 		} else {
 			mutationTypeName = try values.nestedContainer(keyedBy: NameKey.self, forKey: .mutationType).decode(String.self, forKey: .name)
+		}
+		if try values.decodeNil(forKey: .subscriptionType) {
+			subscriptionTypeName = nil
+		} else {
+			subscriptionTypeName = try values.nestedContainer(keyedBy: NameKey.self, forKey: .subscriptionType).decode(String.self, forKey: .name)
 		}
 		types = try values.decode([SchemaType].self, forKey: .types)
 		directives = try values.decode([Directive].self, forKey: .directives)

--- a/Sources/SyrupCore/GraphQL/SelectionSetVisitor.swift
+++ b/Sources/SyrupCore/GraphQL/SelectionSetVisitor.swift
@@ -66,6 +66,8 @@ class SelectionSetVisitor: GraphQLBaseVisitor {
 			parentType = schema.queryType
 		case .mutation:
 			parentType = schema.mutationType!
+		case .subscription:
+			parentType = schema.subscriptionType!
 		default:
 			fatalError("Parsing unsupported operation of type \(operation.operationType)")
 		}
@@ -79,6 +81,8 @@ class SelectionSetVisitor: GraphQLBaseVisitor {
 			operationType = .query(schema.queryType.name)
 		case .mutation:
 			operationType = .mutation(schema.mutationType!.name)
+		case .subscription:
+			operationType = .subscription(schema.subscriptionType!.name)
 		default:
 			fatalError("Parsing unsupported operation of type \(operation.operationType)")
 		}
@@ -383,10 +387,11 @@ extension SelectionSetVisitor {
 	enum OperationType {
 		case mutation(String)
 		case query(String)
+		case subscription(String)
 		
 		var name: String {
 			switch self {
-			case .mutation(let name), .query(let name):
+			case .mutation(let name), .query(let name), .subscription(let name):
 				return name
 			}
 		}

--- a/Sources/SyrupCore/GraphQL/SwiftGraphQLParser+Extensions.swift
+++ b/Sources/SyrupCore/GraphQL/SwiftGraphQLParser+Extensions.swift
@@ -25,7 +25,7 @@
 import Foundation
 import SwiftGraphQLParser
 
-func parse(queries: [String], mutations: [String], fragments: [String]) throws -> Document {
-	let graphQLString = [fragments, queries, mutations].flatMap { $0 }.joined(separator: " ")
+func parse(queries: [String], mutations: [String], subscriptions: [String], fragments: [String]) throws -> Document {
+	let graphQLString = [fragments, queries, mutations, subscriptions].flatMap { $0 }.joined(separator: " ")
 	return try parse(graphQLString)
 }

--- a/Sources/SyrupCore/IR/IntermediateRepresentation.swift
+++ b/Sources/SyrupCore/IR/IntermediateRepresentation.swift
@@ -43,11 +43,11 @@ struct IntermediateRepresentation {
 	}
 	
 	enum ParentType: Equatable {
-		case query(String), mutation(String), fragment(String)
+		case query(String), mutation(String), fragment(String), subscription(String)
 		
 		var name: String {
 			switch self {
-			case .query(let name), .mutation(let name), .fragment(let name):
+			case .query(let name), .mutation(let name), .fragment(let name), .subscription(let name):
 				return name
 			}
 		}
@@ -59,6 +59,8 @@ struct IntermediateRepresentation {
 			case (.mutation(let lhsName), .mutation(let rhsName)):
 				return lhsName == rhsName
 			case (.fragment(let lhsName), .fragment(let rhsName)):
+				return lhsName == rhsName
+			case (.subscription(let lhsName), .subscription(let rhsName)):
 				return lhsName == rhsName
 			default:
 				return false
@@ -222,7 +224,7 @@ struct IntermediateRepresentation {
 	}
 	
 	enum OperationType {
-		case query, mutation
+		case query, mutation, subscription
 	}
 	
 	struct FragmentDefinition: NamedItem {
@@ -377,6 +379,16 @@ extension Array where Element == IntermediateRepresentation.OperationDefinition 
 	var queries: [IntermediateRepresentation.OperationDefinition] {
 		return filter {
 			if case .query = $0.type {
+				return true
+			} else {
+				return false
+			}
+		}
+	}
+    
+	var subscriptions: [IntermediateRepresentation.OperationDefinition] {
+		return filter {
+			if case .subscription = $0.type {
 				return true
 			} else {
 				return false

--- a/Sources/SyrupCore/Reporter/Reporter.swift
+++ b/Sources/SyrupCore/Reporter/Reporter.swift
@@ -59,6 +59,7 @@ public final class Reporter {
 				builtInScalars: config.template.specification.builtInScalars,
 				queries: opsVisitor.queries,
 				mutations: opsVisitor.mutations,
+				subscriptions: opsVisitor.subscriptions,
 				fragments: opsVisitor.fragments
 		)
 

--- a/Sources/SyrupCore/Stencil Extensions/SelectionSetExtension.swift
+++ b/Sources/SyrupCore/Stencil Extensions/SelectionSetExtension.swift
@@ -68,6 +68,8 @@ class SelectionSetExtension: Extension {
 			return ".mutation(\"\(mutationType)\")"
 		case .query(let queryType):
 			return ".query(\"\(queryType)\")"
+		case .subscription(let subscriptionType):
+			return ".subscription(\"\(subscriptionType)\")"
 		}
 	}
 	

--- a/Sources/SyrupCore/Stencil Extensions/SyrupStencilExtension.swift
+++ b/Sources/SyrupCore/Stencil Extensions/SyrupStencilExtension.swift
@@ -46,6 +46,9 @@ final class SyrupStencilExtension: Extension {
 		registerFilter("replace", filter: SyrupStencilExtension.replace)
 		registerFilter("replaceQuotes", filter: SyrupStencilExtension.replaceQuotes)
 		registerFilter("capitalizeFirstLetter", filter: SyrupStencilExtension.capitalizeFirstLetter)
+		registerFilter("renderClassName", filter: SyrupStencilExtension.renderClassName)
+		registerFilter("renderPackage", filter: SyrupStencilExtension.renderPackage)
+		registerFilter("renderOperationTypeName", filter: SyrupStencilExtension.renderOperationTypeName)
 	}
 	
 	// MARK: - Custom Filters
@@ -90,5 +93,34 @@ final class SyrupStencilExtension: Extension {
 	static func capitalizeFirstLetter(_ value: Any?) throws -> Any? {
 		guard let value = value as? String else { return nil }
 		return value.capitalized
+	}
+	
+	static func renderPackage(_ value: Any?) throws -> Any? {
+		guard let value = value as? IntermediateRepresentation.OperationDefinition else { return nil }
+		switch(value.type) {
+			case .query:
+				return "queries"
+			case .mutation:
+				return "mutations"
+			case .subscription:
+				return "subscriptions"
+		}
+	}
+
+	static func renderClassName(_ value: Any?) throws -> Any? {
+		guard let value = value as? IntermediateRepresentation.OperationDefinition else { return nil }
+		switch(value.type) {
+			case .query:
+				return "\(value.name)Query"
+			case .mutation:
+				return "\(value.name)Mutation"
+			case .subscription:
+				return "\(value.name)Subscription"
+		}
+	}
+	
+	static func renderOperationTypeName(_ value: Any?) throws -> Any? {
+		guard let value = value as? IntermediateRepresentation.OperationDefinition else { return nil }
+		return "\(value.type)".capitalized
 	}
 }

--- a/Templates/Kotlin/GraphApi.stencil
+++ b/Templates/Kotlin/GraphApi.stencil
@@ -37,6 +37,8 @@ interface Query<T : Response> : SyrupOperation<T>
 
 interface Mutation<T : Response> : SyrupOperation<T>
 
+interface Subscription<T : Response> : SyrupOperation<T>
+
 interface Response
 
 object OperationGsonBuilder {

--- a/Templates/Kotlin/Operation.stencil
+++ b/Templates/Kotlin/Operation.stencil
@@ -1,5 +1,5 @@
 {% if asFile %}
-package {% if moduleName %}{{ moduleName }}{% else %}com.shopify.syrup{% endif %}.{% if isQuery %}queries{% else %}mutations{% endif %}
+package {% if moduleName %}{{ moduleName }}{% else %}com.shopify.syrup{% endif %}.{{ operation|renderPackage }}
 
 {{ header }}
 import com.google.gson.*
@@ -13,7 +13,7 @@ import javax.annotation.Generated
 
 @Generated("{% if moduleName %}{{ moduleName }}{% else %}com.shopify.syrup{% endif %}")
 {% endif %}
-class {{ name }}({{ operation.variables|renderKotlinArguments }}): {% if isQuery %}Query{% else %}Mutation{% endif %}<{{ operation.name }}Response> {
+class {{ operation|renderClassName }}({{ operation.variables|renderKotlinArguments }}): {{ operation|renderOperationTypeName }}<{{ operation.name }}Response> {
 
     override val rawQueryString = "{{ queryString|replace:"$","\$"|replaceQuotes }}"
 

--- a/Templates/Swift/GraphApi.stencil
+++ b/Templates/Swift/GraphApi.stencil
@@ -150,9 +150,10 @@ public enum GraphSelections {
 	public enum OperationType {
 		case mutation(String)
 		case query(String)
+		case subscription(String)
 		public var name: String {
 			switch self {
-			case .mutation(let name), .query(let name):
+			case .mutation(let name), .query(let name), .subscription(let name):
 				return name
 			}
 		}

--- a/Templates/Swift/Operation.stencil
+++ b/Templates/Swift/Operation.stencil
@@ -1,7 +1,7 @@
 {% extends "Base.stencil" %}
 
 {% block content %}
-	{% if not asFile %}{{ accessLevel }} {% endif %}struct {{ name }}: GraphApiQuery, ResponseAssociable, Equatable {
+	{% if not asFile %}{{ accessLevel }} {% endif %}struct {{ operation|renderClassName }}: GraphApiQuery, ResponseAssociable, Equatable {
 		// MARK: - Query Variables
 		{% for variable in operation.variables %}
 			{{ accessLevel }} let {{ variable.name|escapeReservedWord }}: {{ variable.type|renderVariableType }}

--- a/Tests/Resources/ExpectedKotlinCode/GraphApi.kt
+++ b/Tests/Resources/ExpectedKotlinCode/GraphApi.kt
@@ -37,6 +37,8 @@ interface Query<T : Response> : SyrupOperation<T>
 
 interface Mutation<T : Response> : SyrupOperation<T>
 
+interface Subscription<T : Response> : SyrupOperation<T>
+
 interface Response
 
 object OperationGsonBuilder {

--- a/Tests/Resources/ExpectedKotlinCode/Queries/NodeInterfacesQuery.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Queries/NodeInterfacesQuery.kt
@@ -14,7 +14,7 @@ import javax.annotation.Generated
 @Generated("com.shopify.syrup")
 class NodeInterfacesQuery(var nodeId: ID): Query<NodeInterfacesResponse> {
 
-    override val rawQueryString = "fragment NodeId on Node { __typename id } fragment ProductNodeTitle on Product { __typename title } query NodeInterfaces(\$nodeId: ID!) { __typename node(id: \$nodeId) { __typename __typename ... NodeId ... on Product { __typename ... ProductNodeTitle } } }"
+    override val rawQueryString = "fragment NodeId on Node { __typename id } fragment ProductNodeTitle on Product { __typename title } query NodeInterfaces(\$nodeId: ID!) { __typename node(id: \$nodeId) { __typename ... NodeId ... on Product { __typename ... ProductNodeTitle } } }"
 
     override fun decodeResponse(jsonObject: JsonObject): NodeInterfacesResponse {
         return NodeInterfacesResponse(jsonObject)

--- a/Tests/Resources/ExpectedKotlinCode/Queries/TestQuery10Query.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Queries/TestQuery10Query.kt
@@ -14,7 +14,7 @@ import javax.annotation.Generated
 @Generated("com.shopify.syrup")
 class TestQuery10Query(var priceRuleId: ID): Query<TestQuery10Response> {
 
-    override val rawQueryString = "query TestQuery10(\$priceRuleId: ID!) { __typename priceRule(id: \$priceRuleId) { __typename id value { __typename __typename ... on PriceRulePercentValue { __typename percentage }... on PriceRuleFixedAmountValue { __typename amount } } valueV2 { __typename __typename ... on MoneyV2 { __typename amount }... on PricingPercentageValue { __typename percentage } } } }"
+    override val rawQueryString = "query TestQuery10(\$priceRuleId: ID!) { __typename priceRule(id: \$priceRuleId) { __typename id value { __typename ... on PriceRulePercentValue { __typename percentage }... on PriceRuleFixedAmountValue { __typename amount } } valueV2 { __typename ... on MoneyV2 { __typename amount }... on PricingPercentageValue { __typename percentage } } } }"
 
     override fun decodeResponse(jsonObject: JsonObject): TestQuery10Response {
         return TestQuery10Response(jsonObject)

--- a/Tests/Resources/ExpectedKotlinCode/Queries/TestQuery11Query.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Queries/TestQuery11Query.kt
@@ -14,7 +14,7 @@ import javax.annotation.Generated
 @Generated("com.shopify.syrup")
 class TestQuery11Query(var productId: ID): Query<TestQuery11Response> {
 
-    override val rawQueryString = "query TestQuery11(\$productId: ID!) { __typename node(id: \$productId) { __typename __typename ... on Product { __typename id collections(first: 100) { __typename edges { __typename node { __typename id title } } } }... on ProductOption { __typename id } } }"
+    override val rawQueryString = "query TestQuery11(\$productId: ID!) { __typename node(id: \$productId) { __typename ... on Product { __typename id collections(first: 100) { __typename edges { __typename node { __typename id title } } } }... on ProductOption { __typename id } } }"
 
     override fun decodeResponse(jsonObject: JsonObject): TestQuery11Response {
         return TestQuery11Response(jsonObject)

--- a/Tests/Resources/ExpectedKotlinCode/Responses/Subscription1Response.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/Subscription1Response.kt
@@ -1,0 +1,20 @@
+
+package com.shopify.syrup.responses
+
+import com.shopify.foundation.syrupsupport.*
+import com.shopify.syrup.enums.*
+import java.math.BigDecimal
+import org.joda.time.DateTime
+import com.google.gson.JsonObject
+import javax.annotation.Generated
+
+@Generated("com.shopify.syrup")
+data class Subscription1Response(
+
+    val presenceChanged: Boolean
+) : Response {
+    constructor(jsonObject: JsonObject) : this(
+        presenceChanged = OperationGsonBuilder.gson.fromJson(jsonObject.get("presenceChanged"), Boolean::class.java)
+    )
+
+}

--- a/Tests/Resources/ExpectedKotlinCode/Subscriptions/Subscription1Subscription.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Subscriptions/Subscription1Subscription.kt
@@ -1,0 +1,35 @@
+
+package com.shopify.syrup.subscriptions
+
+import com.shopify.foundation.syrupsupport.*
+import com.google.gson.*
+import java.math.BigDecimal
+import org.joda.time.DateTime
+import com.shopify.syrup.enums.*
+import com.shopify.syrup.inputs.*
+import com.shopify.syrup.fragments.*
+import com.shopify.syrup.responses.*
+import javax.annotation.Generated
+
+@Generated("com.shopify.syrup")
+class Subscription1Subscription(): Subscription<Subscription1Response> {
+
+    override val rawQueryString = "subscription Subscription1 { presenceChanged }"
+
+    override fun decodeResponse(jsonObject: JsonObject): Subscription1Response {
+        return Subscription1Response(jsonObject)
+    }
+
+    override val operationVariables = mapOf<String, String>(
+    )
+
+    override val selections = listOf<Selection>(
+Selection(
+name = "presenceChanged",
+type = "Boolean",
+cacheKey = "presenceChanged",
+passedGID = null,
+typeCondition = "Subscription",
+shouldSkipBasedOnConditionalDirective = false,
+selections = listOf<Selection>()))
+}

--- a/Tests/Resources/ExpectedSwiftCode/Fragments/InterfaceFragmentNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Fragments/InterfaceFragmentNext.swift
@@ -95,13 +95,6 @@ extension MerchantApi.InterfaceFragment {
   []
   ))
   , 
-  .field(GraphSelections.Field(name: "__typename", alias: nil
-, arguments: 
-  []
-, parentType: .union("DiscountCode"), type: .scalar("String"), selectionSet: 
-  []
-  ))
-  , 
   .inlineFragment(GraphSelections.InlineFragment(typeCondition: .object("DiscountCodeBasic")
 , selectionSet: 
   [

--- a/Tests/Resources/ExpectedSwiftCode/Fragments/MultiLevelInterfaceFragmentNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Fragments/MultiLevelInterfaceFragmentNext.swift
@@ -132,13 +132,6 @@ extension MerchantApi.MultiLevelInterfaceFragment {
   []
   ))
   , 
-  .field(GraphSelections.Field(name: "__typename", alias: nil
-, arguments: 
-  []
-, parentType: .interface("Event"), type: .scalar("String"), selectionSet: 
-  []
-  ))
-  , 
   .field(GraphSelections.Field(name: "id", alias: nil
 , arguments: 
   []

--- a/Tests/Resources/ExpectedSwiftCode/Fragments/MultiLevelInterfaceFragmentWithOnlyInlineFragmentsNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Fragments/MultiLevelInterfaceFragmentWithOnlyInlineFragmentsNext.swift
@@ -137,13 +137,6 @@ extension MerchantApi.MultiLevelInterfaceFragmentWithOnlyInlineFragments {
   []
   ))
   , 
-  .field(GraphSelections.Field(name: "__typename", alias: nil
-, arguments: 
-  []
-, parentType: .interface("Event"), type: .scalar("String"), selectionSet: 
-  []
-  ))
-  , 
   .inlineFragment(GraphSelections.InlineFragment(typeCondition: .object("CommentEvent")
 , selectionSet: 
   [

--- a/Tests/Resources/ExpectedSwiftCode/Fragments/TopLevelFragmentNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Fragments/TopLevelFragmentNext.swift
@@ -115,13 +115,6 @@ extension MerchantApi.TopLevelFragment {
   []
   ))
   , 
-  .field(GraphSelections.Field(name: "__typename", alias: nil
-, arguments: 
-  []
-, parentType: .interface("Node"), type: .scalar("String"), selectionSet: 
-  []
-  ))
-  , 
   .inlineFragment(GraphSelections.InlineFragment(typeCondition: .object("Product")
 , selectionSet: 
   [

--- a/Tests/Resources/ExpectedSwiftCode/Fragments/UnionFrag2Next.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Fragments/UnionFrag2Next.swift
@@ -149,13 +149,6 @@ extension MerchantApi.UnionFrag2 {
   []
   ))
   , 
-  .field(GraphSelections.Field(name: "__typename", alias: nil
-, arguments: 
-  []
-, parentType: .union("PriceRuleValue"), type: .scalar("String"), selectionSet: 
-  []
-  ))
-  , 
   .inlineFragment(GraphSelections.InlineFragment(typeCondition: .object("PriceRulePercentValue")
 , selectionSet: 
   [

--- a/Tests/Resources/ExpectedSwiftCode/Fragments/UnionFragNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Fragments/UnionFragNext.swift
@@ -93,13 +93,6 @@ extension MerchantApi.UnionFrag {
   []
   ))
   , 
-  .field(GraphSelections.Field(name: "__typename", alias: nil
-, arguments: 
-  []
-, parentType: .union("PriceRuleValue"), type: .scalar("String"), selectionSet: 
-  []
-  ))
-  , 
   .inlineFragment(GraphSelections.InlineFragment(typeCondition: .object("PriceRulePercentValue")
 , selectionSet: 
   [

--- a/Tests/Resources/ExpectedSwiftCode/GraphApi.swift
+++ b/Tests/Resources/ExpectedSwiftCode/GraphApi.swift
@@ -151,9 +151,10 @@ public enum GraphSelections {
 	public enum OperationType {
 		case mutation(String)
 		case query(String)
+		case subscription(String)
 		public var name: String {
 			switch self {
-			case .mutation(let name), .query(let name):
+			case .mutation(let name), .query(let name), .subscription(let name):
 				return name
 			}
 		}

--- a/Tests/Resources/ExpectedSwiftCode/Queries/CustomerEventsQueryNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Queries/CustomerEventsQueryNext.swift
@@ -19,7 +19,7 @@ public extension MerchantApi {
 		public typealias Response = CustomerEventsResponse
 
 		public let queryString: String = """
-		fragment MultiLevelInterfaceFragment on EventConnection { __typename edges { __typename node { __typename __typename id } } } query CustomerEvents { __typename customer(id: "") { __typename events(first: 10) { __typename ... MultiLevelInterfaceFragment } } }
+		fragment MultiLevelInterfaceFragment on EventConnection { __typename edges { __typename node { __typename id } } } query CustomerEvents { __typename customer(id: "") { __typename events(first: 10) { __typename ... MultiLevelInterfaceFragment } } }
 		"""
 	}
 }

--- a/Tests/Resources/ExpectedSwiftCode/Queries/InterfaceFragmentDiscountsQueryQueryNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Queries/InterfaceFragmentDiscountsQueryQueryNext.swift
@@ -19,7 +19,7 @@ public extension MerchantApi {
 		public typealias Response = InterfaceFragmentDiscountsQueryResponse
 
 		public let queryString: String = """
-		fragment InterfaceFragment on DiscountCode { __typename __typename ... on DiscountCodeBasic { __typename createdAt shareableUrls { __typename title url } } } query InterfaceFragmentDiscountsQuery { __typename codeDiscountNodes(first: 1) { __typename edges { __typename node { __typename codeDiscount { __typename ... InterfaceFragment } } } } }
+		fragment InterfaceFragment on DiscountCode { __typename ... on DiscountCodeBasic { __typename createdAt shareableUrls { __typename title url } } } query InterfaceFragmentDiscountsQuery { __typename codeDiscountNodes(first: 1) { __typename edges { __typename node { __typename codeDiscount { __typename ... InterfaceFragment } } } } }
 		"""
 	}
 }

--- a/Tests/Resources/ExpectedSwiftCode/Queries/MultiLevelInterfaceFragmentWithOnlyInlineFragmentsQueryQueryNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Queries/MultiLevelInterfaceFragmentWithOnlyInlineFragmentsQueryQueryNext.swift
@@ -19,7 +19,7 @@ public extension MerchantApi {
 		public typealias Response = MultiLevelInterfaceFragmentWithOnlyInlineFragmentsQueryResponse
 
 		public let queryString: String = """
-		fragment MultiLevelInterfaceFragmentWithOnlyInlineFragments on EventConnection { __typename edges { __typename node { __typename __typename ... on CommentEvent { __typename id } } } } query MultiLevelInterfaceFragmentWithOnlyInlineFragmentsQuery { __typename customer(id: "") { __typename events(first: 1) { __typename ... MultiLevelInterfaceFragmentWithOnlyInlineFragments } } }
+		fragment MultiLevelInterfaceFragmentWithOnlyInlineFragments on EventConnection { __typename edges { __typename node { __typename ... on CommentEvent { __typename id } } } } query MultiLevelInterfaceFragmentWithOnlyInlineFragmentsQuery { __typename customer(id: "") { __typename events(first: 1) { __typename ... MultiLevelInterfaceFragmentWithOnlyInlineFragments } } }
 		"""
 	}
 }

--- a/Tests/Resources/ExpectedSwiftCode/Queries/TopLevelFragmentQueryQueryNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Queries/TopLevelFragmentQueryQueryNext.swift
@@ -19,7 +19,7 @@ public extension MerchantApi {
 		public typealias Response = TopLevelFragmentQueryResponse
 
 		public let queryString: String = """
-		fragment TopLevelFragment on QueryRoot { __typename node(id: "") { __typename __typename ... on Product { __typename id } } } query TopLevelFragmentQuery { __typename ... TopLevelFragment }
+		fragment TopLevelFragment on QueryRoot { __typename node(id: "") { __typename ... on Product { __typename id } } } query TopLevelFragmentQuery { __typename ... TopLevelFragment }
 		"""
 	}
 }

--- a/Tests/Resources/ExpectedSwiftCode/Queries/Union1QueryNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Queries/Union1QueryNext.swift
@@ -19,7 +19,7 @@ public extension MerchantApi {
 		public typealias Response = Union1Response
 
 		public let queryString: String = """
-		query Union1 { __typename priceRule(id: "") { __typename id value { __typename __typename ... on PriceRulePercentValue { __typename percentage }... on PriceRuleFixedAmountValue { __typename amount } } } }
+		query Union1 { __typename priceRule(id: "") { __typename id value { __typename ... on PriceRulePercentValue { __typename percentage }... on PriceRuleFixedAmountValue { __typename amount } } } }
 		"""
 	}
 }
@@ -65,13 +65,6 @@ extension MerchantApi.Union1Query {
   []
 , parentType: .object("PriceRule"), type: .union("PriceRuleValue"), selectionSet: 
   [
-  .field(GraphSelections.Field(name: "__typename", alias: nil
-, arguments: 
-  []
-, parentType: .union("PriceRuleValue"), type: .scalar("String"), selectionSet: 
-  []
-  ))
-  , 
   .field(GraphSelections.Field(name: "__typename", alias: nil
 , arguments: 
   []

--- a/Tests/Resources/ExpectedSwiftCode/Queries/Union2QueryNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Queries/Union2QueryNext.swift
@@ -19,7 +19,7 @@ public extension MerchantApi {
 		public typealias Response = Union2Response
 
 		public let queryString: String = """
-		fragment UnionFrag on PriceRuleValue { __typename __typename ... on PriceRulePercentValue { __typename percentage }... on PriceRuleFixedAmountValue { __typename amount } } query Union2 { __typename priceRule(id: "") { __typename value { __typename ... UnionFrag } } }
+		fragment UnionFrag on PriceRuleValue { __typename ... on PriceRulePercentValue { __typename percentage }... on PriceRuleFixedAmountValue { __typename amount } } query Union2 { __typename priceRule(id: "") { __typename value { __typename ... UnionFrag } } }
 		"""
 	}
 }

--- a/Tests/Resources/ExpectedSwiftCode/Queries/Union3QueryNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Queries/Union3QueryNext.swift
@@ -19,7 +19,7 @@ public extension MerchantApi {
 		public typealias Response = Union3Response
 
 		public let queryString: String = """
-		fragment UnionFrag2 on QueryRoot { __typename priceRule(id: "") { __typename value { __typename __typename ... on PriceRulePercentValue { __typename percentage }... on PriceRuleFixedAmountValue { __typename amount } } } } query Union3 { __typename ... UnionFrag2 }
+		fragment UnionFrag2 on QueryRoot { __typename priceRule(id: "") { __typename value { __typename ... on PriceRulePercentValue { __typename percentage }... on PriceRuleFixedAmountValue { __typename amount } } } } query Union3 { __typename ... UnionFrag2 }
 		"""
 	}
 }

--- a/Tests/Resources/ExpectedSwiftCode/Responses/Subscription1ResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/Subscription1ResponseNext.swift
@@ -1,0 +1,21 @@
+// Syrup auto-generated file
+import Foundation
+
+public extension MerchantApi {
+struct Subscription1Response: GraphApiResponse, Equatable {
+	// MARK: - Response Fields
+		public var presenceChanged: Bool
+
+	// MARK: - Helpers
+	public let __typename: String
+
+	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
+	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+
+	public init(presenceChanged: Bool) {
+			self.presenceChanged = presenceChanged
+			self.__typename = "Subscription"
+	}
+
+}
+}

--- a/Tests/Resources/ExpectedSwiftCode/Subscriptions/Subscription1SubscriptionNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Subscriptions/Subscription1SubscriptionNext.swift
@@ -1,0 +1,41 @@
+// Syrup auto-generated file
+import Foundation
+
+public extension MerchantApi {
+	struct Subscription1Subscription: GraphApiQuery, ResponseAssociable, Equatable {
+		// MARK: - Query Variables
+
+		// MARK: - Initializer
+		public init() {
+		}
+
+		// MARK: - Helpers
+
+		public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+
+		private enum CodingKeys: CodingKey {
+		}
+
+		public typealias Response = Subscription1Response
+
+		public let queryString: String = """
+		subscription Subscription1 { presenceChanged }
+		"""
+	}
+}
+
+
+extension MerchantApi.Subscription1Subscription {
+  public static let operationSelections: GraphSelections.Operation? = GraphSelections.Operation(
+    type: .subscription("Subscription"),
+    selectionSet: 
+  [
+  .field(GraphSelections.Field(name: "presenceChanged", alias: nil
+, arguments: 
+  []
+, parentType: .object("Subscription"), type: .scalar("Boolean"), selectionSet: 
+  []
+  ))
+  ]
+  )
+}

--- a/Tests/Resources/TestOperations/Kotlin/Subscriptions.graphql
+++ b/Tests/Resources/TestOperations/Kotlin/Subscriptions.graphql
@@ -1,0 +1,3 @@
+subscription Subscription1 {
+	presenceChanged
+}

--- a/Tests/Resources/TestOperations/Swift/Test.graphql
+++ b/Tests/Resources/TestOperations/Swift/Test.graphql
@@ -511,3 +511,7 @@ query NullableCustomCodedScalar {
     fileSize
   }
 }
+
+subscription Subscription1 {
+	presenceChanged
+}

--- a/Tests/Swift/TestResources/Shopify-Schema.json
+++ b/Tests/Swift/TestResources/Shopify-Schema.json
@@ -7,7 +7,9 @@
 			"mutationType": {
 				"name": "Mutation"
 			},
-			"subscriptionType": null,
+			"subscriptionType": {
+				"name": "Subscription"
+			},
 			"types": [{
 				"kind": "OBJECT",
 				"name": "AccessScope",
@@ -37092,6 +37094,30 @@
 				"interfaces": null,
 				"enumValues": null,
 				"possibleTypes": null
+			}, {
+				"kind": "OBJECT",
+				"name": "Subscription",
+				"description": "The schema's entry point for all mutation operations.",
+				"inputFields": null,
+				"interfaces": [],
+				"enumValues": null,
+				"possibleTypes": null,
+				"fields": [{
+					"args": [],
+					"deprecationReason": null,
+					"description": "",
+					"isDeprecated": false,
+					"name": "presenceChanged",
+					"type": {
+						"kind": "NON_NULL",
+						"name": null,
+						"ofType": {
+							"kind": "SCALAR",
+							"name": "Boolean",
+							"ofType": null
+						}
+					}
+				}]
 			}, {
 				"kind": "OBJECT",
 				"name": "Mutation",


### PR DESCRIPTION
## Update
- as per review comments, decided to treat `typename` as a real selection and added it in the parser here https://github.com/Shopify/SwiftGraphQLParser/pull/2

## What is this doing
- generate subscription types
- add a test type to the schema
- generate a basic test file
- collapse rendering methods into a single `renderOperation` method

Not included:
- configure selections on each operation type

## Tophat instructions
- look at the code
- examine the generated subscription models
- will the swift models compile (I checked in xcode and it seems they do)

This work is a continuation of @lwise 's work here https://github.com/Shopify/syrup/pull/21