### PR TITLE
Fix typename on subscription response root that causes decoding to fail

### DIFF
--- a/Templates/Swift/ResponseType.stencil
+++ b/Templates/Swift/ResponseType.stencil
@@ -25,8 +25,10 @@
 		{{ accessLevel }} var as{{ fragment.name }}Fragment: {{ moduleName }}.{{ fragment.name }}{% if fragment.conditionallySelected %}?{% endif %}
 	{% endfor %}
 
+	{% if graphQLName != "Subscription" %}
 	// MARK: - Helpers
 	{{ accessLevel }} let __typename: String
+	{% endif %}
 
 	public static let customDecoder: JSONDecoder = {{ moduleName }}.customDecoder
 	public static let customEncoder: JSONEncoder = {{ moduleName }}.customEncoder

--- a/Tests/Resources/ExpectedSwiftCode/Responses/Subscription1ResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/Subscription1ResponseNext.swift
@@ -6,9 +6,6 @@ struct Subscription1Response: GraphApiResponse, Equatable {
 	// MARK: - Response Fields
 		public var presenceChanged: Bool
 
-	// MARK: - Helpers
-	public let __typename: String
-
 	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
 	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
 


### PR DESCRIPTION
iOS responses assume there will be a `__typename` field available on the root of the json response. That is not the case for subscriptions.