### PR TITLE
Upgrade to Swift 5.3.1

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,7 +17,7 @@ jobs:
   Linux:
 
     runs-on: ubuntu-latest
-    container: swift:5.0
+    container: swift:5.3.1
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: GitHub Action for SwiftLint (Only files changed in the PR)
-        uses: norio-nomura/action-swiftlint@3.1.0
+        uses: norio-nomura/action-swiftlint@3.2.0
         env:
           DIFF_BASE: ${{ github.base_ref }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM swift:5.0
+FROM swift:5.3.1
 COPY . /syrup
 WORKDIR /syrup

--- a/Sources/Syrup/Syrup.swift
+++ b/Sources/Syrup/Syrup.swift
@@ -67,8 +67,8 @@ class Syrup {
 			let configFileDefaults = [".syrup.yml", "syrup.yml"]
 			let projectDefaults = configFileDefaults.lazy.map { currentWorkingDirectory.appending(component: $0) }
 			self.project = projectDefaults.first {
-				return localFileSystem.isFile($0)
-				} ?? projectDefaults[0]
+				localFileSystem.isFile($0)
+			} ?? projectDefaults[0]
 			self.schema = self.project
 		}
 
@@ -99,7 +99,7 @@ class Syrup {
 		}
 
 		func addAsSubparser(to parser: ArgumentParser) -> ArgumentParser {
-			return parser.add(subparser: self.rawValue, overview: self.overview)
+			parser.add(subparser: self.rawValue, overview: self.overview)
 		}
 	}
 
@@ -295,52 +295,52 @@ class Syrup {
 
 	@discardableResult
 	private func addQueriesArgument(to parser: ArgumentParser) -> PositionalArgument<PathArgument> {
-		return parser.add(positional: "queries", kind: PathArgument.self, usage: "This provides the path to the folder containing all of your graphql operation definitions. These files are expected to have the .graphql suffix and should be valid graphql operations.")
+		parser.add(positional: "queries", kind: PathArgument.self, usage: "This provides the path to the folder containing all of your graphql operation definitions. These files are expected to have the .graphql suffix and should be valid graphql operations.")
 	}
 	
 	@discardableResult
 	private func addDestinationArgument(to parser: ArgumentParser) -> PositionalArgument<PathArgument> {
-		return parser.add(positional: "destination", kind: PathArgument.self, usage: "This provides the path to the folder where the generated code should be written to.")
+		parser.add(positional: "destination", kind: PathArgument.self, usage: "This provides the path to the folder where the generated code should be written to.")
 	}
 	
 	@discardableResult
 	private func addSupportFilesArgument(to parser: ArgumentParser) -> PositionalArgument<PathArgument> {
-		return parser.add(positional: "supportFilesDestination", kind: PathArgument.self, usage: "This provides the path to the folder where the necessary support files should be written to.")
+		parser.add(positional: "supportFilesDestination", kind: PathArgument.self, usage: "This provides the path to the folder where the necessary support files should be written to.")
 	}
 	
 	@discardableResult
 	private func addTemplateArgument(to parser: ArgumentParser) -> PositionalArgument<String> {
-		return parser.add(positional: "template", kind: String.self, usage: "This provides the path to the Templates folder that are included in the Syrup repository.", completion: .filename)
+		parser.add(positional: "template", kind: String.self, usage: "This provides the path to the Templates folder that are included in the Syrup repository.", completion: .filename)
 	}
 	
 	@discardableResult
 	private func addProjectArgument(to parser: ArgumentParser) -> OptionArgument<PathArgument> {
-		return parser.add(option: "--project", kind: PathArgument.self, usage: "YAML project configuration file")
+		parser.add(option: "--project", kind: PathArgument.self, usage: "YAML project configuration file")
 	}
 
 	@discardableResult
 	private func addSchemaArgument(to parser: ArgumentParser) -> OptionArgument<PathArgument> {
-		return parser.add(option: "--schema", kind: PathArgument.self, usage: "YAML schema configuration file")
+		parser.add(option: "--schema", kind: PathArgument.self, usage: "YAML schema configuration file")
 	}
 
 	@discardableResult
 	private func addOverrideSchemaArgument(to parser: ArgumentParser) -> OptionArgument<String> {
-		return parser.add(option: "--override-schema", kind: String.self, usage: "Overrides the projects schema location. Can be either a URL or a path on the filesystem.")
+		parser.add(option: "--override-schema", kind: String.self, usage: "Overrides the projects schema location. Can be either a URL or a path on the filesystem.")
 	}
 
 	@discardableResult
 	private func addDeprecationReportArgument(to parser: ArgumentParser) -> OptionArgument<PathArgument> {
-		return parser.add(option: "--reports", kind: PathArgument.self, usage: "Deprecation report target output file.")
+		parser.add(option: "--reports", kind: PathArgument.self, usage: "Deprecation report target output file.")
 	}
 
 	@discardableResult
 	private func addOverwriteReportArgument(to parser: ArgumentParser) -> OptionArgument<Bool> {
-		return parser.add(option: "--overwrite", shortName: "-ow", kind: Bool.self, usage: "Overwrite existing report.")
+		parser.add(option: "--overwrite", shortName: "-ow", kind: Bool.self, usage: "Overwrite existing report.")
 	}
 
 	@discardableResult
 	private func addVerboseArgument(to parser: ArgumentParser) -> OptionArgument<Bool> {
-		return parser.add(option: "--verbose", shortName: "-vb", kind: Bool.self, usage: "Verbose output, reports on duplicates, etc.")
+		parser.add(option: "--verbose", shortName: "-vb", kind: Bool.self, usage: "Verbose output, reports on duplicates, etc.")
 	}
 
 }

--- a/Sources/SyrupCore/Extensions/Array+Extensions.swift
+++ b/Sources/SyrupCore/Extensions/Array+Extensions.swift
@@ -37,8 +37,8 @@ extension Array where Element: Hashable {
 
 extension Array {
 	func all(_ transform: (Element) -> Bool) -> Bool {
-		return self.reduce(true) { (result, element) -> Bool in
-			return result && transform(element)
+		self.reduce(true) { (result, element) -> Bool in
+			result && transform(element)
 		}
 	}
 }

--- a/Sources/SyrupCore/Extensions/String+Extensions.swift
+++ b/Sources/SyrupCore/Extensions/String+Extensions.swift
@@ -25,17 +25,17 @@ import Foundation
 
 extension String {
 	func indented(indentStr: String = "\t") -> String {
-		return self.split(separator: "\n")
+		self.split(separator: "\n")
 			.map({ indentStr + $0 + "\n" })
 			.joined()
 	}
 	
 	var capitalizedFirstLetter: String {
-		return self.prefix(1).uppercased() + self.suffix(self.count - 1)
+		self.prefix(1).uppercased() + self.suffix(self.count - 1)
 	}
 	
 	var lowercasedFirstLetter: String {
-		return self.prefix(1).lowercased() + self.suffix(self.count - 1)
+		self.prefix(1).lowercased() + self.suffix(self.count - 1)
 	}
 	
 	var removingExcessNewlines: String {
@@ -53,7 +53,7 @@ extension String {
 	}
 	
 	var removingNewLines: String {
-		return self.replacingOccurrences(of: "\n", with: " ")
+		self.replacingOccurrences(of: "\n", with: " ")
 	}
 	
 	func removeSuffix(_ suffix: String) -> String {

--- a/Sources/SyrupCore/File Specifications/ReportSpec.swift
+++ b/Sources/SyrupCore/File Specifications/ReportSpec.swift
@@ -68,7 +68,7 @@ public struct ReportSpec: Codable {
 	}
 
 	public func toDictionary() throws -> [DeprecationType: [String: Date]] {
-		return self.deprecations.reduce(into: [DeprecationType: [String: Date]]()) { result, deprecation in
+		self.deprecations.reduce(into: [DeprecationType: [String: Date]]()) { result, deprecation in
 			if var parent = result[deprecation.type] {
 				parent[deprecation.key] = deprecation.value
 				result[deprecation.type] = parent

--- a/Sources/SyrupCore/File Specifications/SchemaSpec.swift
+++ b/Sources/SyrupCore/File Specifications/SchemaSpec.swift
@@ -45,7 +45,7 @@ public struct SchemaSpec: Codable {
 		}
 		
 		static func scalars(_ scalars: [ScalarType]) -> [CustomScalar] {
-			return scalars.map {
+			scalars.map {
 				if let customCodedScalar = $0 as? IntermediateRepresentation.CustomCodedScalar {
 					return CustomScalar(graphType: $0.graphType, nativeType: $0.nativeType, rawValueType: customCodedScalar.rawValueType)
 				} else {
@@ -71,7 +71,9 @@ public struct SchemaSpec: Codable {
 		let container = try decoder.container(keyedBy: CodingKeys.self)
 		self.location = try container.decode(String.self, forKey: .location)
 		let customScalars = try container.decode([CustomScalar].self, forKey: .customScalars)
-		self.customScalars = customScalars.map { return $0.scalarIR }
+		self.customScalars = customScalars.map {
+			$0.scalarIR
+		}
 	}
 	
 	public func encode(to encoder: Encoder) throws {

--- a/Sources/SyrupCore/Generator/Generator.swift
+++ b/Sources/SyrupCore/Generator/Generator.swift
@@ -133,7 +133,7 @@ public final class Generator {
 		let error: Error
 		
 		var errorDescription: String? {
-			return "Error parsing \(fileName): \(error.localizedDescription)"
+			"Error parsing \(fileName): \(error.localizedDescription)"
 		}
 	}
 
@@ -211,7 +211,7 @@ public final class Generator {
 			let renderer = KotlinRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.queries }, fileType: .query, renderer: { (ir) -> [String] in
-				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.queries)
+				try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.queries)
 			})
 		}
 		
@@ -219,7 +219,7 @@ public final class Generator {
 			let renderer = KotlinRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.mutations }, fileType: .mutation, renderer: { (ir) -> [String] in
-				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations:  ir.operations.mutations)
+				try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.mutations)
 			})
 		}
 		
@@ -233,7 +233,7 @@ public final class Generator {
 			let renderer = KotlinRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.fragmentDefinitions }, fileType: .fragment, renderer: { (ir) -> [String] in
-				return try renderer.renderFragmentDefinitions(intermediateRepresentation: ir, selectionSets: selectionSets)
+				try renderer.renderFragmentDefinitions(intermediateRepresentation: ir, selectionSets: selectionSets)
 			})
 		}
         
@@ -241,7 +241,7 @@ public final class Generator {
 			let renderer = KotlinRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.subscriptions }, fileType: .subscription, renderer: { (ir) -> [String] in
-				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.subscriptions)
+				try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.subscriptions)
 			})
 		}
 		
@@ -300,7 +300,7 @@ public final class Generator {
 			let renderer = SwiftRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.fragmentDefinitions }, fileType: .fragment, renderer: { (ir) -> [String] in
-				return try renderer.renderFragmentDefinitions(intermediateRepresentation: ir, selectionSets: selectionSets)
+				try renderer.renderFragmentDefinitions(intermediateRepresentation: ir, selectionSets: selectionSets)
 			})
 		}
 		
@@ -308,7 +308,7 @@ public final class Generator {
 			let renderer = SwiftRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.queries }, fileType: .query, renderer: { (ir) -> [String] in
-				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations:  ir.operations.queries)
+				try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.queries)
 			})
 		}
 		
@@ -316,7 +316,8 @@ public final class Generator {
 			let renderer = SwiftRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.mutations }, fileType: .mutation, renderer: { (ir) -> [String] in
-				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations:  ir.operations.mutations) })
+				try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.mutations)
+			})
 		}
 		
 		concurrentPerform {
@@ -329,7 +330,7 @@ public final class Generator {
 			let renderer = SwiftRenderer(config: self.config)
 			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.subscriptions }, fileType: .subscription, renderer: { (ir) -> [String] in
-				return try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.subscriptions)
+				try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.subscriptions)
 			})
 		}
 		

--- a/Sources/SyrupCore/Generator/Kotlin/KotlinRenderer.swift
+++ b/Sources/SyrupCore/Generator/Kotlin/KotlinRenderer.swift
@@ -28,7 +28,7 @@ import PathKit
 
 final class KotlinRenderer: Renderer {
 	override class func customExtensions(config: Config) -> [Extension] {
-		return [
+		[
 			KotlinRenderer.customExtension(),
 			ReservedWordsExtension(reservedWords: config.template.specification.reservedWords),
 			ArgumentRendererExtension<KotlinVariableTypeRenderer>(
@@ -40,11 +40,11 @@ final class KotlinRenderer: Renderer {
 	}
 
 	func renderGraphApi() throws -> String {
-		return try render(template: "GraphApi", context: [:])
+		try render(template: "GraphApi", context: [:])
 	}
 
 	func renderInputWrapper() throws -> String {
-		return try render(template: "InputWrapper", context: [:])
+		try render(template: "InputWrapper", context: [:])
 	}
 
 	func renderResponseTypes(intermediateRepresentation: IntermediateRepresentation) throws -> [String] {
@@ -243,7 +243,7 @@ final class KotlinRenderer: Renderer {
 	}
 
 	static func decodeJsonScalarField(collectedScalarField: IntermediateRepresentation.CollectedScalarField, nonNull: Bool, fieldName: String) -> String {
-		return decodeJsonScalarField(field: collectedScalarField, fieldType: collectedScalarField.type, fieldName: fieldName, nonNull: nonNull)
+		decodeJsonScalarField(field: collectedScalarField, fieldType: collectedScalarField.type, fieldName: fieldName, nonNull: nonNull)
 	}
 
 	static func decodeJsonScalarField(field: IntermediateRepresentation.CollectedScalarField, fieldType: FieldTypeProtocol, fieldName: String, nonNull: Bool) -> String {
@@ -272,7 +272,7 @@ final class KotlinRenderer: Renderer {
 
 	//Decode Object Type fields
 	static func decodeJsonObjectField(collectedObjectFieldType: IntermediateRepresentation.CollectedObjectField, nonNull: Bool, fieldName: String) -> String {
-		return decodeJsonObjectField(collectedObjectField: collectedObjectFieldType, objectFieldType: collectedObjectFieldType.type, nonNull: nonNull, fieldName: fieldName)
+		decodeJsonObjectField(collectedObjectField: collectedObjectFieldType, objectFieldType: collectedObjectFieldType.type, nonNull: nonNull, fieldName: fieldName)
 	}
 
 	static func decodeJsonObjectField(collectedObjectField: IntermediateRepresentation.CollectedObjectField?, objectFieldType: FieldTypeProtocol, nonNull: Bool, fieldName: String) -> String {

--- a/Sources/SyrupCore/Generator/Kotlin/KotlinTypeAnnotationRenderer.swift
+++ b/Sources/SyrupCore/Generator/Kotlin/KotlinTypeAnnotationRenderer.swift
@@ -27,7 +27,7 @@ import Foundation
 enum KotlinTypeAnnotationRenderer {
 	
 	static func render(scalarField: IntermediateRepresentation.CollectedScalarField, outsideOfModule moduleName: String? = nil) -> String {
-		return render(scalarType: scalarField.type, nonNull: false, moduleName: moduleName)
+		render(scalarType: scalarField.type, nonNull: false, moduleName: moduleName)
 	}
 	
 	private static func render(scalarType: FieldTypeProtocol, nonNull: Bool, moduleName: String?) -> String {

--- a/Sources/SyrupCore/Generator/Kotlin/KotlinVariableTypeRenderer.swift
+++ b/Sources/SyrupCore/Generator/Kotlin/KotlinVariableTypeRenderer.swift
@@ -26,11 +26,11 @@ import Foundation
 
 struct KotlinVariableTypeRenderer: VariableTypeRenderer {
 	static func render(variableType: IntermediateRepresentation.Variable.VariableType) -> String {
-		return render(variableType: variableType, nonNull: false, inputVariable: false)
+		render(variableType: variableType, nonNull: false, inputVariable: false)
 	}
 	
 	static func render(inputVariableType: IntermediateRepresentation.Variable.VariableType) -> String {
-		return render(variableType: inputVariableType, nonNull: false, inputVariable: true)
+		render(variableType: inputVariableType, nonNull: false, inputVariable: true)
 	}
 	
 	private static func render(variableType: IntermediateRepresentation.Variable.VariableType, nonNull: Bool, inputVariable: Bool) -> String {

--- a/Sources/SyrupCore/Generator/Renderer.swift
+++ b/Sources/SyrupCore/Generator/Renderer.swift
@@ -28,7 +28,7 @@ import PathKit
 
 open class Renderer {
 	class func customExtensions(config: Config) -> [Extension] {
-		return []
+		[]
 	}
 	let config: Config
 	let environment: Environment
@@ -52,7 +52,7 @@ open class Renderer {
 			"asFile": asFile,
 			"moduleName": config.project.moduleName
 		]
-		let mergedContext = context.merging(globalContext, uniquingKeysWith: { value, _ in return value })
+		let mergedContext = context.merging(globalContext, uniquingKeysWith: { value, _ in value })
 		let templateName = "\(template).stencil"
 		do {
 			let rendered = try environment.renderTemplate(name: templateName, context: mergedContext)

--- a/Sources/SyrupCore/Generator/Swift/SwiftRenderer.swift
+++ b/Sources/SyrupCore/Generator/Swift/SwiftRenderer.swift
@@ -28,7 +28,7 @@ import PathKit
 
 final class SwiftRenderer: Renderer {
 	override class func customExtensions(config: Config) -> [Extension] {
-		return [
+		[
 			SwiftRenderer.customExtension(config: config),
 			SwiftNestedRendererExtension(config: config),
 			ReservedWordsExtension(reservedWords: config.template.specification.reservedWords),
@@ -102,7 +102,7 @@ final class SwiftRenderer: Renderer {
 	}
 		
 	func renderGraphApi() throws -> String {
-		return try render(template: "GraphApi", context: [:])
+		try render(template: "GraphApi", context: [:])
 	}
 	
 	func renderModuleDefinition(moduleName: String, hasCustomCodedScalars: Bool) throws -> String {

--- a/Sources/SyrupCore/Generator/Swift/SwiftTypeAnnotationRenderer.swift
+++ b/Sources/SyrupCore/Generator/Swift/SwiftTypeAnnotationRenderer.swift
@@ -26,7 +26,7 @@ import Foundation
 
 enum SwiftTypeAnnotationRenderer {
 	static func render(scalarField: IntermediateRepresentation.CollectedScalarField, outsideOfModule moduleName: String? = nil) -> String {
-		return render(scalarType: scalarField.type, nonNull: false, moduleName: moduleName)
+		render(scalarType: scalarField.type, nonNull: false, moduleName: moduleName)
 	}
 	
 	private static func render(scalarType: FieldTypeProtocol, nonNull: Bool, moduleName: String?) -> String {

--- a/Sources/SyrupCore/Generator/Swift/SwiftVariableTypeRenderer.swift
+++ b/Sources/SyrupCore/Generator/Swift/SwiftVariableTypeRenderer.swift
@@ -26,11 +26,11 @@ import Foundation
 
 enum SwiftVariableTypeRenderer: VariableTypeRenderer {
 	static func render(variableType: IntermediateRepresentation.Variable.VariableType) -> String {
-		return render(variableType: variableType, nonNull: false, inputVariable: false)
+		render(variableType: variableType, nonNull: false, inputVariable: false)
 	}
 	
 	static func render(inputVariableType: IntermediateRepresentation.Variable.VariableType) -> String {
-		return render(variableType: inputVariableType, nonNull: false, inputVariable: true)
+		render(variableType: inputVariableType, nonNull: false, inputVariable: true)
 	}
 	
 	private static func render(variableType: IntermediateRepresentation.Variable.VariableType, nonNull: Bool, inputVariable: Bool) -> String {

--- a/Sources/SyrupCore/GraphQL/IntermediateRepresentationVisitor.swift
+++ b/Sources/SyrupCore/GraphQL/IntermediateRepresentationVisitor.swift
@@ -38,7 +38,7 @@ class IntermediateRepresentationVisitor: GraphQLBaseVisitor {
 	private var referencedEnums: Set<IntermediateRepresentation.EnumType> = []
 	private var referencedInputTypes: Set<IntermediateRepresentation.InputType> = []
 	var intermediateRepresentation: IntermediateRepresentation {
-		return IntermediateRepresentation(operations: operations, fragmentDefinitions: fragmentDefinitions, referencedEnums: Array(referencedEnums), referencedInputTypes: Array(referencedInputTypes))
+		IntermediateRepresentation(operations: operations, fragmentDefinitions: fragmentDefinitions, referencedEnums: Array(referencedEnums), referencedInputTypes: Array(referencedInputTypes))
 	}
 	
 	private var parentType = Stack<Schema.SchemaType>()
@@ -59,7 +59,7 @@ class IntermediateRepresentationVisitor: GraphQLBaseVisitor {
 		let description: String
 		
 		var errorDescription: String? {
-			return description
+			description
 		}
 	}
 	
@@ -83,8 +83,6 @@ class IntermediateRepresentationVisitor: GraphQLBaseVisitor {
 			schemaType = schema.mutationType!
 		case .subscription:
 			schemaType = schema.subscriptionType!
-		default:
-			throw Error(description: "Cannot create operation type of \(operation.operationType)")
 		}
 		parentType.push(schemaType)
 	}
@@ -342,7 +340,7 @@ class IntermediateRepresentationVisitor: GraphQLBaseVisitor {
 		let topLevelType = schema.type(named: name)
 		
 		let enumValues = topLevelType.enumValues.map {
-			return IntermediateRepresentation.EnumType.Value(
+			IntermediateRepresentation.EnumType.Value(
 				value: $0.name,
 				attributes: IntermediateRepresentation.Attributes(
 					description: $0.description,

--- a/Sources/SyrupCore/GraphQL/OperationVisitor.swift
+++ b/Sources/SyrupCore/GraphQL/OperationVisitor.swift
@@ -30,7 +30,7 @@ final class OperationVisitor: GraphQLBaseVisitor {
 		let description: String
 		
 		var errorDescription: String? {
-			return description
+			description
 		}
 	}
 	public var queries: [String: String] = [:]

--- a/Sources/SyrupCore/GraphQL/Schema.swift
+++ b/Sources/SyrupCore/GraphQL/Schema.swift
@@ -32,7 +32,7 @@ struct Schema: Decodable {
 	let directives: [Directive]
 	
 	var queryType: SchemaType {
-		return self.type(named: queryTypeName)
+        self.type(named: queryTypeName)
 	}
 	
 	var mutationType: SchemaType? {

--- a/Sources/SyrupCore/IR/IntermediateRepresentation+CollectedField.swift
+++ b/Sources/SyrupCore/IR/IntermediateRepresentation+CollectedField.swift
@@ -36,7 +36,7 @@ protocol CollectedField {
 
 extension CollectedField {
 	var parentType: String {
-		return parentTypeCondition.name
+		parentTypeCondition.name
 	}
 }
 
@@ -130,7 +130,7 @@ extension IntermediateRepresentation {
 		
 		private(set) var path: [PathComponent]
 		var parent: PathComponent {
-			return path.first!
+			path.first!
 		}
 		
 		func with(_ pathComponent: PathComponent) -> SelectionPath {
@@ -163,11 +163,11 @@ extension IntermediateRepresentation {
 		}
 		
 		static func ==(lhs: SelectionPath, rhs: SelectionPath) -> Bool {
-			return lhs.path == rhs.path
+			lhs.path == rhs.path
 		}
 		
 		func hasPrefix(_ prefix: SelectionPath) -> Bool {
-			return Array(path.prefix(upTo: prefix.path.count)) == prefix.path
+			Array(path.prefix(upTo: prefix.path.count)) == prefix.path
 		}
 		
 		/// Returns true if the field is a result of a fragment spread
@@ -181,7 +181,7 @@ extension IntermediateRepresentation {
 		}
 		
 		var count: Int {
-			return path.count
+			path.count
 		}
 	}
 	
@@ -214,7 +214,7 @@ extension IntermediateRepresentation {
 	}
 	
 	private func filterTypeNameField(collectedFields: [CollectedField]) -> [CollectedField] {
-		return collectedFields.compactMap { field in
+		collectedFields.compactMap { field in
 			switch field {
 			case var field as CollectedObjectField:
 				field.collectedFields = filterTypeNameField(collectedFields: field.collectedFields)
@@ -457,7 +457,7 @@ extension IntermediateRepresentation {
 	private static func mergeDuplicateFields(fields: [CollectedField]) throws -> [CollectedField] {
 		var mergedFields: [CollectedField] = []
 		func areDuplicates(lhs: CollectedField, rhs: CollectedField) -> Bool {
-			return lhs.name == rhs.name && lhs.parentType == rhs.parentType && lhs.parentFragment == rhs.parentFragment
+			lhs.name == rhs.name && lhs.parentType == rhs.parentType && lhs.parentFragment == rhs.parentFragment
 		}
 		for field in fields {
 			if let mergedIndex = mergedFields.firstIndex(where: { areDuplicates(lhs: $0, rhs: field) }) {
@@ -493,7 +493,7 @@ extension IntermediateRepresentation {
 		var mergedFields: [CollectedField] = []
 		let fields = inheritedFields + concreteFields
 		func areDuplicates(lhs: CollectedField, rhs: CollectedField) -> Bool {
-			return lhs.name == rhs.name
+			lhs.name == rhs.name
 		}
 		for (index, field) in fields.enumerated() {
 			var finalField = field
@@ -559,11 +559,11 @@ extension IntermediateRepresentation {
 	}
 	
 	static func fragments(from fragmentSpreads: [IntermediateRepresentation.SelectionPath], onInterfaceType interfaceType: String) -> [IntermediateRepresentation.SelectionPath.PathComponent.Fragment] {
-		return fragments(from: fragmentSpreads, onType: interfaceType, isInterfaceType: true)
+		fragments(from: fragmentSpreads, onType: interfaceType, isInterfaceType: true)
 	}
 	
 	static func fragments(from fragmentSpreads: [IntermediateRepresentation.SelectionPath], onConcreteType concreteType: String) -> [IntermediateRepresentation.SelectionPath.PathComponent.Fragment] {
-		return fragments(from: fragmentSpreads, onType: concreteType, isInterfaceType: false)
+		fragments(from: fragmentSpreads, onType: concreteType, isInterfaceType: false)
 	}
 	
 	private static func fragments(from fragmentSpreads: [IntermediateRepresentation.SelectionPath], onType type: String, isInterfaceType: Bool) -> [IntermediateRepresentation.SelectionPath.PathComponent.Fragment] {
@@ -656,7 +656,7 @@ extension IntermediateRepresentation {
 extension Array where Element == CollectedField {
 	func groupedFields(fromInterfaceType interfaceType: String) throws -> [String: [CollectedField]] {
 		var grouped = Dictionary(grouping: self) { (collectedField) -> String in
-			return collectedField.parentType
+			collectedField.parentType
 		}
 		for collectedField in self {
 			switch collectedField.parentTypeCondition {
@@ -668,13 +668,13 @@ extension Array where Element == CollectedField {
 		}
 		let baseFields = self.baseFields(fromInterfaceType: interfaceType)
 		return try grouped.mapValues { (fields) -> [CollectedField] in
-			return try IntermediateRepresentation.mergeDuplicateFields(forInterfaceType: interfaceType, inheritedFields: baseFields, concreteFields: fields)
+			try IntermediateRepresentation.mergeDuplicateFields(forInterfaceType: interfaceType, inheritedFields: baseFields, concreteFields: fields)
 		}
 	}
 	
 	func groupedFields(fromUnionType unionType: String) -> [String: [CollectedField]] {
 		var grouped = Dictionary(grouping: self) { (collectedField) -> String in
-			return collectedField.parentType
+			collectedField.parentType
 		}
 		for collectedField in self {
 			switch collectedField.parentTypeCondition {
@@ -731,7 +731,7 @@ extension Array where Element == CollectedField {
 	}
 	
 	func computedFragmentFields(fragmentSpreads: [IntermediateRepresentation.SelectionPath.PathComponent.Fragment], parentType: String) -> [CollectedField] {
-		return computedFragmentFields(fragmentSpreads: fragmentSpreads, parentTypes: [parentType])
+		computedFragmentFields(fragmentSpreads: fragmentSpreads, parentTypes: [parentType])
 	}
 	
 	func computedFragmentFields(fragmentSpreads: [IntermediateRepresentation.SelectionPath.PathComponent.Fragment], parentTypes: [String]) -> [CollectedField] {
@@ -752,7 +752,7 @@ extension Array where Element == CollectedField {
 		}
 		
 		computedFragmentFields = computedFragmentFields.filter { field in
-			return !duplicateFields.contains(field.name)
+			!duplicateFields.contains(field.name)
 		}
 		
 		return computedFragmentFields

--- a/Sources/SyrupCore/IR/IntermediateRepresentation+FieldType.swift
+++ b/Sources/SyrupCore/IR/IntermediateRepresentation+FieldType.swift
@@ -39,7 +39,7 @@ extension FieldTypeProtocol {
 	}
 	
 	var isNonNull: Bool {
-		return self is IntermediateRepresentation.NonNullFieldType
+		self is IntermediateRepresentation.NonNullFieldType
 	}
 	
 	var isObject: Bool {

--- a/Sources/SyrupCore/IR/IntermediateRepresentation.swift
+++ b/Sources/SyrupCore/IR/IntermediateRepresentation.swift
@@ -279,7 +279,7 @@ struct IntermediateRepresentation {
 		}
 		
 		static func ==(lhs: InputType, rhs: InputType) -> Bool {
-			return lhs.name == rhs.name
+			lhs.name == rhs.name
 		}
 	}
 	
@@ -293,7 +293,7 @@ struct IntermediateRepresentation {
 			}
 			
 			static func ==(lhs: Value, rhs: Value) -> Bool {
-				return lhs.value == rhs.value
+				lhs.value == rhs.value
 			}
 		}
 		let name: String
@@ -306,7 +306,7 @@ struct IntermediateRepresentation {
 		}
 		
 		static func ==(lhs: EnumType, rhs: EnumType) -> Bool {
-			return lhs.name == rhs.name && lhs.values == rhs.values
+			lhs.name == rhs.name && lhs.values == rhs.values
 		}
 	}
 	
@@ -357,7 +357,7 @@ struct IntermediateRepresentation {
 private extension Array where Element == IntermediateRepresentation.FragmentDefinition {
 	subscript(index: String) -> IntermediateRepresentation.FragmentDefinition {
 		get {
-			return self.first(where: { (fragmentDefinition) -> Bool in
+			self.first(where: { (fragmentDefinition) -> Bool in
 				fragmentDefinition.name == index
 			})!
 		}
@@ -367,7 +367,7 @@ private extension Array where Element == IntermediateRepresentation.FragmentDefi
 
 extension Array where Element == IntermediateRepresentation.OperationDefinition {
 	var mutations: [IntermediateRepresentation.OperationDefinition] {
-		return filter {
+		filter {
 			if case .mutation = $0.type {
 				return true
 			} else {
@@ -377,7 +377,7 @@ extension Array where Element == IntermediateRepresentation.OperationDefinition 
 	}
 	
 	var queries: [IntermediateRepresentation.OperationDefinition] {
-		return filter {
+		filter {
 			if case .query = $0.type {
 				return true
 			} else {
@@ -387,7 +387,7 @@ extension Array where Element == IntermediateRepresentation.OperationDefinition 
 	}
     
 	var subscriptions: [IntermediateRepresentation.OperationDefinition] {
-		return filter {
+		filter {
 			if case .subscription = $0.type {
 				return true
 			} else {

--- a/Sources/SyrupCore/Reporter/Reporter.swift
+++ b/Sources/SyrupCore/Reporter/Reporter.swift
@@ -196,16 +196,18 @@ public final class Reporter {
 		removedHandler: ((String, Date)) -> Void
 		
 	) -> [DeprecationType: [String: Date]] {
-		return DeprecationType.allCases.reduce(into: [DeprecationType: [String: Date]]()) { result, type in
+        DeprecationType.allCases.reduce(into: [DeprecationType: [String: Date]]()) { result, type in
 			let oldType = old[type] ?? [:]
 			let newType = new[type] ?? [:]
-			
+
 			result[type] = oldType.combineWith(new: newType)
-			
+
 			headerHandler(type.rawValue.uppercased())
-			
+
 			result[type]?
-				.sorted { $0.key < $1.key }
+				.sorted {
+					$0.key < $1.key
+				}
 				.forEach { existing in
 					existingHandler(existing)
 				}
@@ -213,7 +215,7 @@ public final class Reporter {
 			oldType
 				.filterRemoved(new: newType)
 				.sorted {
-					return $0.key < $1.key
+					$0.key < $1.key
 				}
 				.forEach { removed in
 					removedHandler(removed)
@@ -229,12 +231,20 @@ let alertDuration: Int = 7
 extension String {
 
 	func ansi(_ code: String) -> String {
-		return "\u{001B}[\(code)m\(self)\u{001B}[0m"
+		"\u{001B}[\(code)m\(self)\u{001B}[0m"
 	}
-	
-	func mdH1() -> String { return "#\(self)" }
-	func mdH2() -> String { return "##\(self)" }
-	func mdH3() -> String { return "###\(self)" }
+
+	func mdH1() -> String {
+		"#\(self)"
+	}
+
+	func mdH2() -> String {
+		"##\(self)"
+	}
+
+	func mdH3() -> String {
+		"###\(self)"
+	}
 
 	func mdExpiryFlag(_ value: Date) -> String {
 		let expiryDate = Calendar.current.date(byAdding: Calendar.Component.day, value: expiryDuration, to: value)!
@@ -248,11 +258,22 @@ extension String {
 			return self.mdTodo()
 		}
 	}
-	
-	func mdTodo() -> String { return "- \(self)" }
-	func mdAlert() -> String { return self.mdSpan("color:red") + " 🚨" }
-	func mdWarn() -> String { return self.mdSpan("color:darkorange") + " ⚠️" }
-	func mdSpan(_ style: String) -> String { return "<span style=\"\(style)\">\(self)</span>" }
+
+	func mdTodo() -> String {
+		"- \(self)"
+	}
+
+	func mdAlert() -> String {
+		self.mdSpan("color:red") + " 🚨"
+	}
+
+	func mdWarn() -> String {
+		self.mdSpan("color:darkorange") + " ⚠️"
+	}
+
+	func mdSpan(_ style: String) -> String {
+		"<span style=\"\(style)\">\(self)</span>"
+	}
 
 	func ansiExpiryFlag(_ value: Date) -> String {
 		let expiryDate = Calendar.current.date(byAdding: Calendar.Component.day, value: expiryDuration, to: value)!
@@ -267,21 +288,28 @@ extension String {
 		}
 	}
 
-	func ansiAlert() -> String { return self.ansi("31") + " 🚨" }
-	func ansiWarn() -> String { return self.ansi("33") + " ⚠️" }
+	func ansiAlert() -> String {
+		self.ansi("31") + " 🚨"
+	}
+
+	func ansiWarn() -> String {
+		self.ansi("33") + " ⚠️"
+	}
 
 }
 
 extension Dictionary where Key == String, Value == Date {
 	func filterRemoved(new: [Key: Value]) -> [Key: Value] {
-		return self.filter { key, value in !new.keys.contains(key) }
+		self.filter { key, value in
+			!new.keys.contains(key)
+		}
 	}
 }
 
 extension Dictionary { // where Key == String, Value == Date {
 	func combineWith(new: [Key: Value]) -> [Key: Value] {
 		// We default to our existing/self copy, if none exist we add the new one.
-		return new.reduce(into: [Key: Value]()) { result, element in
+		new.reduce(into: [Key: Value]()) { result, element in
 			result[element.key] = self[element.key] ?? element.value
 		}
 	}
@@ -293,7 +321,7 @@ enum ValidationError: Error {
 
 extension File {
 	func yamlRead<T: Decodable>() throws -> T {
-		return try YAMLDecoder().decode(T.self, from: URL(fileURLWithPath: self.path), userInfo: [:])
+		try YAMLDecoder().decode(T.self, from: URL(fileURLWithPath: self.path), userInfo: [:])
 	}
 
 	func yamlWrite<T: Encodable>(encodable: T) throws {
@@ -312,7 +340,7 @@ extension File {
 
 extension Sequence where Iterator.Element == File {
 	func toLoaded() throws -> [String: String] {
-		return try self.reduce(into: [String: String]()) { (results, file) in
+		try self.reduce(into: [String: String]()) { (results, file) in
 			results[file.name] = try file.load()
 		}
 	}
@@ -320,8 +348,10 @@ extension Sequence where Iterator.Element == File {
 
 extension Folder {
 	func fetchGraphQLFiles(suffix: String = "graphql") throws -> [String: String] {
-		return try self.files.recursive
-				.filter { (file: File) in file.extension == suffix }
-				.toLoaded()
+		try self.files.recursive
+			.filter { (file: File) in
+				file.extension == suffix
+			}
+			.toLoaded()
 	}
 }

--- a/Sources/SyrupCore/Stencil Extensions/MapNode.swift
+++ b/Sources/SyrupCore/Stencil Extensions/MapNode.swift
@@ -35,11 +35,11 @@ class MapNode: NodeType {
 		let components = token.components()
 		
 		func hasToken(_ token: String, at index: Int) -> Bool {
-			return components.indices ~= index + 1 && components[index] == token
+			components.indices ~= index + 1 && components[index] == token
 		}
 		
 		func endsOrHasToken(_ token: String, at index: Int) -> Bool {
-			return components.count == index || hasToken(token, at: index)
+			components.count == index || hasToken(token, at: index)
 		}
 		
 		guard hasToken("into", at: 2) && endsOrHasToken("using", at: 4) else {

--- a/Sources/SyrupCore/Stencil Extensions/SyrupTemplate.swift
+++ b/Sources/SyrupCore/Stencil Extensions/SyrupTemplate.swift
@@ -39,7 +39,7 @@ open class SyrupTemplate: Stencil.Template {
 	}
 	
 	open override func render(_ dictionary: [String: Any]? = nil) throws -> String {
-		return try removeExtraLines(from: super.render(dictionary))
+		try removeExtraLines(from: super.render(dictionary))
 	}
 	
 	// Workaround until Stencil fixes https://github.com/kylef/Stencil/issues/22

--- a/Sources/SyrupCore/Stencil Extensions/WithNode.swift
+++ b/Sources/SyrupCore/Stencil Extensions/WithNode.swift
@@ -55,7 +55,7 @@ final class WithNode: NodeType {
 			throw TemplateSyntaxError("Variable \(variable.variable) couldn't be resolved.")
 		}
 		return try context.push(dictionary: [name: variableResult]) {
-			return try renderNodes(nodes, context)
+			try renderNodes(nodes, context)
 		}
 	}
 }

--- a/Sources/SyrupCore/Utilities/Loaders.swift
+++ b/Sources/SyrupCore/Utilities/Loaders.swift
@@ -24,6 +24,10 @@
 
 import Foundation
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 func loadSchema(location: String) throws -> Schema {
 	let url = URL(string: location)!
 	let schemaData: Data

--- a/Sources/SyrupCore/Utilities/Stack.swift
+++ b/Sources/SyrupCore/Utilities/Stack.swift
@@ -33,15 +33,15 @@ struct Stack<Element> {
 	
 	@discardableResult
 	mutating func pop() -> Element {
-		return items.removeLast()
+		items.removeLast()
 	}
 	
 	func peek() -> Element {
-		return items.last!
+		items.last!
 	}
 	
 	var isEmpty: Bool {
-		return items.isEmpty
+		items.isEmpty
 	}
 	
 	mutating func transformTopElement(_ transform: (inout Element) -> Void) {

--- a/Sources/SyrupCore/Utilities/Synchronized.swift
+++ b/Sources/SyrupCore/Utilities/Synchronized.swift
@@ -35,8 +35,8 @@ struct Synchronized<T> {
 	
 	var value: T {
 		get {
-			return lock.withLock {
-				return _value
+			lock.withLock {
+				_value
 			}
 		}
 		set {


### PR DESCRIPTION
Brings us to the latest version of Swift (which supports Windows!), and modernizes some of the code base.

On Linux, Swift has moved URL related classes to a `FoundationNetworking` module, so we're conditionally importing it as per https://github.com/apple/swift-corelibs-foundation/pull/2289.