### PR TITLE
Escaping fields which are a reserved word

### DIFF
--- a/Sources/SyrupCore/Generator/Kotlin/KotlinRenderer.swift
+++ b/Sources/SyrupCore/Generator/Kotlin/KotlinRenderer.swift
@@ -29,7 +29,7 @@ import PathKit
 final class KotlinRenderer: Renderer {
 	override class func customExtensions(config: Config) -> [Extension] {
 		[
-			KotlinRenderer.customExtension(),
+			KotlinRenderer.customExtension(config: config),
 			ReservedWordsExtension(reservedWords: config.template.specification.reservedWords),
 			ArgumentRendererExtension<KotlinVariableTypeRenderer>(
 					reservedWords: config.template.specification.reservedWords,
@@ -185,9 +185,12 @@ final class KotlinRenderer: Renderer {
 		return try render(template: "InterfaceWrapper", asFile: asFile, context: context)
 	}
 
-	private static func customExtension() -> Extension {
+	private static func customExtension(config: Config) -> Extension {
 		let customExtension = Extension()
 
+		func escape(_ word: String) -> String {
+			return ReservedWordsExtension.escape(word: word, reservedWords: config.template.specification.reservedWords)
+		}
 		customExtension.registerFilter("renderPropertyDeclaration") { (value, args) -> Any? in
 
 			enum Context: String {
@@ -202,16 +205,16 @@ final class KotlinRenderer: Renderer {
 				if case .interfaceWrapper = context {
 					prefix = "Base\(field.parentType.capitalizedFirstLetter)"
 				}
-				return "\(field.name): \(KotlinTypeAnnotationRenderer.render(objectField: field, prefix: prefix))"
+				return "\(escape(field.name)): \(KotlinTypeAnnotationRenderer.render(objectField: field, prefix: prefix))"
 			} else if let field = value as? IntermediateRepresentation.CollectedScalarField {
-				return "\(field.name): \(KotlinTypeAnnotationRenderer.render(scalarField: field))"
+				return "\(escape(field.name)): \(KotlinTypeAnnotationRenderer.render(scalarField: field))"
 			} else if let field = value as? IntermediateRepresentation.CollectedUnionField {
-				return "\(field.name): \(KotlinTypeAnnotationRenderer.render(unionWrapper: field))"
+				return "\(escape(field.name)): \(KotlinTypeAnnotationRenderer.render(unionWrapper: field))"
 			} else if let field = value as? IntermediateRepresentation.CollectedInterfaceField {
 				if case .interfaceWrapper = context {
 					prefix = "Base\(field.parentType.capitalizedFirstLetter)"
 				}
-				return "\(field.name): \(KotlinTypeAnnotationRenderer.render(interfaceWrapper: field, prefix: prefix))"
+				return "\(escape(field.name)): \(KotlinTypeAnnotationRenderer.render(interfaceWrapper: field, prefix: prefix))"
 			}
 			return nil
 		}
@@ -237,7 +240,7 @@ final class KotlinRenderer: Renderer {
 			} else {
 				fatalError("Unable to determine type annotation \(field)")
 			}
-			return "\(fieldName) = \(typeAnnotation)"
+			return "\(escape(fieldName)) = \(typeAnnotation)"
 		}
 		return customExtension
 	}

--- a/Sources/SyrupCore/Generator/Kotlin/KotlinRenderer.swift
+++ b/Sources/SyrupCore/Generator/Kotlin/KotlinRenderer.swift
@@ -189,7 +189,7 @@ final class KotlinRenderer: Renderer {
 		let customExtension = Extension()
 
 		func escape(_ word: String) -> String {
-			return ReservedWordsExtension.escape(word: word, reservedWords: config.template.specification.reservedWords)
+			ReservedWordsExtension.escape(word: word, reservedWords: config.template.specification.reservedWords)
 		}
 		customExtension.registerFilter("renderPropertyDeclaration") { (value, args) -> Any? in
 

--- a/Sources/SyrupCore/Generator/Swift/SwiftRenderer.swift
+++ b/Sources/SyrupCore/Generator/Swift/SwiftRenderer.swift
@@ -220,7 +220,7 @@ final class SwiftRenderer: Renderer {
 		let customExtension = Extension()
 		
 		func escape(_ word: String) -> String {
-			return ReservedWordsExtension.escape(word: word, reservedWords: config.template.specification.reservedWords)
+			ReservedWordsExtension.escape(word: word, reservedWords: config.template.specification.reservedWords)
 		}
 		
 		customExtension.registerFilter("renderInterfaceWrapperTypeAlias", filter: { value, args -> Any? in

--- a/Sources/SyrupCore/Generator/Swift/SwiftRenderer.swift
+++ b/Sources/SyrupCore/Generator/Swift/SwiftRenderer.swift
@@ -219,6 +219,10 @@ final class SwiftRenderer: Renderer {
 	private static func customExtension(config: Config) -> Extension {
 		let customExtension = Extension()
 		
+		func escape(_ word: String) -> String {
+			return ReservedWordsExtension.escape(word: word, reservedWords: config.template.specification.reservedWords)
+		}
+		
 		customExtension.registerFilter("renderInterfaceWrapperTypeAlias", filter: { value, args -> Any? in
 			guard let field = value as? CollectedField, let accessLevel = args.first as? String else { return nil }
 			
@@ -234,14 +238,15 @@ final class SwiftRenderer: Renderer {
 		})
 		
 		customExtension.registerFilter("renderPropertyDeclaration") { value -> Any? in
+			
 			if let field = value as? IntermediateRepresentation.CollectedObjectField {
-				return "\(field.name): \(SwiftTypeAnnotationRenderer.render(objectField: field))"
+				return "\(escape(field.name)): \(SwiftTypeAnnotationRenderer.render(objectField: field))"
 			} else if let field = value as? IntermediateRepresentation.CollectedScalarField {
-				return "\(field.name): \(SwiftTypeAnnotationRenderer.render(scalarField: field))"
+				return "\(escape(field.name)): \(SwiftTypeAnnotationRenderer.render(scalarField: field))"
 			} else if let field = value as? IntermediateRepresentation.CollectedInterfaceField {
-				return "\(field.name): \(SwiftTypeAnnotationRenderer.render(interfaceWrapper: field))"
+				return "\(escape(field.name)): \(SwiftTypeAnnotationRenderer.render(interfaceWrapper: field))"
 			} else if let field = value as? IntermediateRepresentation.CollectedUnionField {
-				return "\(field.name): \(SwiftTypeAnnotationRenderer.render(unionWrapper: field))"
+				return "\(escape(field.name)): \(SwiftTypeAnnotationRenderer.render(unionWrapper: field))"
 			}
 			return nil
 		}
@@ -278,9 +283,10 @@ final class SwiftRenderer: Renderer {
 			} else {
 				fatalError("Unable to determine type annotation \(field)")
 			}
+			let escapedFieldName = escape(fieldName)
 			if let customCodedScalar = field.type.nestedScalar as? IntermediateRepresentation.CustomCodedScalar {
 				return """
-				self.\(fieldName) = try customScalarResolver.decode(\(typeAnnotation).self, rawValueType: \(customCodedScalar.rawValueType).self, forKey: .\(field.name), container: container) { (value) -> \(customCodedScalar.nativeType) in
+				self.\(escapedFieldName) = try customScalarResolver.decode(\(typeAnnotation).self, rawValueType: \(customCodedScalar.rawValueType).self, forKey: .\(field.name), container: container) { (value) -> \(customCodedScalar.nativeType) in
 				return try customScalarResolver.decoderFor\(customCodedScalar.graphType)(value, container.codingPath)
 				}
 				"""
@@ -288,11 +294,11 @@ final class SwiftRenderer: Renderer {
 			
 			if field.type.isNonNull {
 				return """
-				self.\(fieldName) = try container.decode(\(typeAnnotation).self, forKey: .\(field.name))
+				self.\(escapedFieldName) = try container.decode(\(typeAnnotation).self, forKey: .\(field.name))
 				"""
 			} else {
 				return """
-				self.\(fieldName) = try container.decodeIfPresent(\(typeAnnotation.removeSuffix("?")).self, forKey: .\(field.name))
+				self.\(escapedFieldName) = try container.decodeIfPresent(\(typeAnnotation.removeSuffix("?")).self, forKey: .\(field.name))
 				"""
 			}
 		}

--- a/Templates/Kotlin/Template.yml
+++ b/Templates/Kotlin/Template.yml
@@ -5,7 +5,7 @@ reservedWords: [
   "as",
   "as?",
   "break",
-  "classs",
+  "class",
   "continue",
   "do",
   "else",
@@ -36,7 +36,6 @@ reservedWords: [
   "catch",
   "constructor",
   "delegate",
-  "field",
   "file",
   "finally",
   "get",
@@ -77,7 +76,6 @@ reservedWords: [
   "suspend",
   "tailrec",
   "vararg",
-  "field",
   "it"
 ]
 builtInScalars:

--- a/Templates/Swift/InterfaceWrapper.stencil
+++ b/Templates/Swift/InterfaceWrapper.stencil
@@ -11,10 +11,10 @@
 		{% with field.attributes as attributes %}{% include "Helpers/Attributes.stencil" %}{% endwith %}
 		{{ accessLevel }} var {{ field|renderPropertyDeclaration }} {
 			get {
-				return common.{{ field.name }}
+				return common.{{ field.name|escapeReservedWord }}
 			}
 			set {
-				common.{{ field.name }} = newValue
+				common.{{ field.name|escapeReservedWord }} = newValue
 			}
 		}
 	{% endfor %}
@@ -73,13 +73,13 @@
 		}
 	}
 
-	{% map baseFields into initArgs using field %}{{ field.name }}: {{ field|renderType }}{% endmap %}
+	{% map baseFields into initArgs using field %}{{ field.name|escapeReservedWord }}: {{ field|renderType }}{% endmap %}
 	{% map fragmentSpreads into initFragmentArgs using fragment %}{{ fragment.name|lowercasedFirstLetter }}Fragment: {{ moduleName }}.{{ fragment.name }}{% if fragment.conditionallySelected %}?{% endif %}{% endmap %}
 
 	{{ accessLevel }} init(__typename: String, realized: Realized{% if initArgs %}, {% endif %}{{ initArgs|join:", " }}{% if initFragmentArgs %}, {% endif %}{{ initFragmentArgs|join:", " }}) {
 		self.__typename = __typename
 		self.realized = realized
-		{% map baseFields into commonArgs using field %}{{ field.name }}: {{ field.name }}{% endmap %}
+		{% map baseFields into commonArgs using field %}{{ field.name }}: {{ field.name|escapeReservedWord }}{% endmap %}
 		{% map fragmentSpreads into commonFragmentArgs using fragment %}{{ fragment.name|lowercasedFirstLetter }}Fragment: {{ fragment.name|lowercasedFirstLetter }}Fragment{% endmap %}
 		self.common = {{ fallbackTypeName }}({{ commonArgs|join:", " }}{% if commonArgs and commonFragmentArgs %}, {% endif %}{{ commonFragmentArgs|join:", " }})
 	}

--- a/Templates/Swift/ResponseType.stencil
+++ b/Templates/Swift/ResponseType.stencil
@@ -86,11 +86,11 @@
 		}
 	{% endif %}
 
-	{% map fields into initArgs using field %}{{ field.name }}: {{ field|renderType }}{% endmap %}
+	{% map fields into initArgs using field %}{{ field.name|escapeReservedWord }}: {{ field|renderType }}{% endmap %}
 	{% map fragmentSpreads into fragmentArgs using fragment %}{{ fragment.name|lowercasedFirstLetter }}Fragment: {{ moduleName }}.{{ fragment.name }}{% if fragment.conditionallySelected %}?{% endif %}{% endmap %}
 	{{ accessLevel }} init({{ initArgs|join:", " }}{% if fragmentArgs and initArgs %}, {% endif %}{{ fragmentArgs|join:", " }}) {
 		{% for field in fields %}
-			self.{{ field.name }} = {{ field.name|escapeReservedWord }}
+			self.{{ field.name|escapeReservedWord }} = {{ field.name|escapeReservedWord }}
 		{% endfor %}
 		{% for fragment in fragmentSpreads %}
 			self.as{{ fragment.name }}Fragment = {{ fragment.name|lowercasedFirstLetter }}Fragment

--- a/Templates/Swift/ResponseType.stencil
+++ b/Templates/Swift/ResponseType.stencil
@@ -90,7 +90,7 @@
 	{% map fragmentSpreads into fragmentArgs using fragment %}{{ fragment.name|lowercasedFirstLetter }}Fragment: {{ moduleName }}.{{ fragment.name }}{% if fragment.conditionallySelected %}?{% endif %}{% endmap %}
 	{{ accessLevel }} init({{ initArgs|join:", " }}{% if fragmentArgs and initArgs %}, {% endif %}{{ fragmentArgs|join:", " }}) {
 		{% for field in fields %}
-			self.{{ field.name }} = {{ field.name }}
+			self.{{ field.name }} = {{ field.name|escapeReservedWord }}
 		{% endfor %}
 		{% for fragment in fragmentSpreads %}
 			self.as{{ fragment.name }}Fragment = {{ fragment.name|lowercasedFirstLetter }}Fragment

--- a/Tests/Resources/ExpectedKotlinCode/Fragments/TopLevelFragmentWithReservedWord.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Fragments/TopLevelFragmentWithReservedWord.kt
@@ -36,35 +36,26 @@ name = "var",
 type = "ID",
 cacheKey = "var",
 passedGID = null,
-typeCondition = "Product",
+typeCondition = "Node",
 shouldSkipBasedOnConditionalDirective = false,
 selections = listOf<Selection>()))))
         }
     }
 
 data class Node(
-    val realized: Realized
+    val realized: Realized,
+    val `var`: ID 
 ): Response {
     constructor(jsonObject: JsonObject) : this (
         realized = when (jsonObject.get("__typename").asString) {
-            "Product" -> Realized.Product(jsonObject)
             else -> Realized.Other
-        }
+        },
+        `var` = OperationGsonBuilder.gson.fromJson(jsonObject.get("var"), ID::class.java)
     )
  companion object {
    const val typeName = "Node"
  }
  sealed class Realized {
-data class Product(
-    /**
-     * Globally unique identifier.
-     */
-    val `var`: ID
-) : Realized() {
-    constructor(jsonObject: JsonObject) : this(
-        `var` = OperationGsonBuilder.gson.fromJson(jsonObject.get("var"), ID::class.java)
-    )
-}
     object Other: Realized()
 }
 }

--- a/Tests/Resources/ExpectedKotlinCode/Fragments/TopLevelFragmentWithReservedWord.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Fragments/TopLevelFragmentWithReservedWord.kt
@@ -1,0 +1,71 @@
+
+package com.shopify.syrup.fragments
+
+import com.shopify.foundation.syrupsupport.*
+import com.shopify.syrup.enums.*
+import java.math.BigDecimal
+import org.joda.time.DateTime
+import com.google.gson.JsonObject
+import javax.annotation.Generated
+
+@Generated("com.shopify.syrup")
+data class TopLevelFragmentWithReservedWord(
+
+    /**
+     * Returns a specific node by ID.
+     */
+    val node: Node?
+) : Response {
+    constructor(jsonObject: JsonObject) : this(
+        node = if (jsonObject.has("node") && !jsonObject.get("node").isJsonNull) Node(jsonObject.getAsJsonObject("node")) else null
+    )
+
+    companion object {
+        fun getSelections(operationVariables: Map<String, String>): List<Selection> {
+            return listOf<Selection>(
+Selection(
+name = "node",
+type = "Node",
+cacheKey = "node(id: )",
+passedGID = null,
+typeCondition = "QueryRoot",
+shouldSkipBasedOnConditionalDirective = false,
+selections = listOf<Selection>(
+Selection(
+name = "var",
+type = "ID",
+cacheKey = "var",
+passedGID = null,
+typeCondition = "Product",
+shouldSkipBasedOnConditionalDirective = false,
+selections = listOf<Selection>()))))
+        }
+    }
+
+data class Node(
+    val realized: Realized
+): Response {
+    constructor(jsonObject: JsonObject) : this (
+        realized = when (jsonObject.get("__typename").asString) {
+            "Product" -> Realized.Product(jsonObject)
+            else -> Realized.Other
+        }
+    )
+ companion object {
+   const val typeName = "Node"
+ }
+ sealed class Realized {
+data class Product(
+    /**
+     * Globally unique identifier.
+     */
+    val `var`: ID
+) : Realized() {
+    constructor(jsonObject: JsonObject) : this(
+        `var` = OperationGsonBuilder.gson.fromJson(jsonObject.get("var"), ID::class.java)
+    )
+}
+    object Other: Realized()
+}
+}
+}

--- a/Tests/Resources/ExpectedKotlinCode/Queries/QueryWithReservedWordOnInlineFragmentQuery.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Queries/QueryWithReservedWordOnInlineFragmentQuery.kt
@@ -1,0 +1,51 @@
+
+package com.shopify.syrup.queries
+
+import com.shopify.foundation.syrupsupport.*
+import com.google.gson.*
+import java.math.BigDecimal
+import org.joda.time.DateTime
+import com.shopify.syrup.enums.*
+import com.shopify.syrup.inputs.*
+import com.shopify.syrup.fragments.*
+import com.shopify.syrup.responses.*
+import javax.annotation.Generated
+
+@Generated("com.shopify.syrup")
+class QueryWithReservedWordOnInlineFragmentQuery(): Query<QueryWithReservedWordOnInlineFragmentResponse> {
+
+    override val rawQueryString = "query QueryWithReservedWordOnInlineFragment { __typename node(id: \\\"123\\\") { __typename id ... on Product { __typename val: title } } }"
+
+    override fun decodeResponse(jsonObject: JsonObject): QueryWithReservedWordOnInlineFragmentResponse {
+        return QueryWithReservedWordOnInlineFragmentResponse(jsonObject)
+    }
+
+    override val operationVariables = mapOf<String, String>(
+    )
+
+    override val selections = listOf<Selection>(
+Selection(
+name = "node",
+type = "Node",
+cacheKey = "node(id: 123)",
+passedGID = null,
+typeCondition = "QueryRoot",
+shouldSkipBasedOnConditionalDirective = false,
+selections = listOf<Selection>(
+Selection(
+name = "id",
+type = "ID",
+cacheKey = "id",
+passedGID = null,
+typeCondition = "Node",
+shouldSkipBasedOnConditionalDirective = false,
+selections = listOf<Selection>()), 
+Selection(
+name = "val",
+type = "String",
+cacheKey = "val",
+passedGID = null,
+typeCondition = "Product",
+shouldSkipBasedOnConditionalDirective = false,
+selections = listOf<Selection>()))))
+}

--- a/Tests/Resources/ExpectedKotlinCode/Queries/QueryWithReservedWordQuery.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Queries/QueryWithReservedWordQuery.kt
@@ -1,0 +1,51 @@
+
+package com.shopify.syrup.queries
+
+import com.shopify.foundation.syrupsupport.*
+import com.google.gson.*
+import java.math.BigDecimal
+import org.joda.time.DateTime
+import com.shopify.syrup.enums.*
+import com.shopify.syrup.inputs.*
+import com.shopify.syrup.fragments.*
+import com.shopify.syrup.responses.*
+import javax.annotation.Generated
+
+@Generated("com.shopify.syrup")
+class QueryWithReservedWordQuery(): Query<QueryWithReservedWordResponse> {
+
+    override val rawQueryString = "query QueryWithReservedWord { __typename class: shop { __typename return: id fun: name } }"
+
+    override fun decodeResponse(jsonObject: JsonObject): QueryWithReservedWordResponse {
+        return QueryWithReservedWordResponse(jsonObject)
+    }
+
+    override val operationVariables = mapOf<String, String>(
+    )
+
+    override val selections = listOf<Selection>(
+Selection(
+name = "class",
+type = "Shop",
+cacheKey = "class",
+passedGID = null,
+typeCondition = "QueryRoot",
+shouldSkipBasedOnConditionalDirective = false,
+selections = listOf<Selection>(
+Selection(
+name = "return",
+type = "ID",
+cacheKey = "return",
+passedGID = null,
+typeCondition = "Shop",
+shouldSkipBasedOnConditionalDirective = false,
+selections = listOf<Selection>()), 
+Selection(
+name = "fun",
+type = "String",
+cacheKey = "fun",
+passedGID = null,
+typeCondition = "Shop",
+shouldSkipBasedOnConditionalDirective = false,
+selections = listOf<Selection>()))))
+}

--- a/Tests/Resources/ExpectedKotlinCode/Responses/QueryWithReservedWordOnInlineFragmentResponse.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/QueryWithReservedWordOnInlineFragmentResponse.kt
@@ -1,0 +1,56 @@
+
+package com.shopify.syrup.responses
+
+import com.shopify.foundation.syrupsupport.*
+import com.shopify.syrup.enums.*
+import java.math.BigDecimal
+import org.joda.time.DateTime
+import com.google.gson.JsonObject
+import javax.annotation.Generated
+
+@Generated("com.shopify.syrup")
+data class QueryWithReservedWordOnInlineFragmentResponse(
+
+    /**
+     * Returns a specific node by ID.
+     */
+    val node: Node?
+) : Response {
+    constructor(jsonObject: JsonObject) : this(
+        node = if (jsonObject.has("node") && !jsonObject.get("node").isJsonNull) Node(jsonObject.getAsJsonObject("node")) else null
+    )
+
+data class Node(
+    val realized: Realized,
+    val id: ID 
+): Response {
+    constructor(jsonObject: JsonObject) : this (
+        realized = when (jsonObject.get("__typename").asString) {
+            "Product" -> Realized.Product(jsonObject)
+            else -> Realized.Other
+        },
+        id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java)
+    )
+ companion object {
+   const val typeName = "Node"
+ }
+ sealed class Realized {
+data class Product(
+    /**
+     * Globally unique identifier.
+     */
+    val id: ID,
+    /**
+     * The title of the product.
+     */
+    val `val`: String
+) : Realized() {
+    constructor(jsonObject: JsonObject) : this(
+        id = OperationGsonBuilder.gson.fromJson(jsonObject.get("id"), ID::class.java),
+        `val` = OperationGsonBuilder.gson.fromJson(jsonObject.get("val"), String::class.java)
+    )
+}
+    object Other: Realized()
+}
+}
+}

--- a/Tests/Resources/ExpectedKotlinCode/Responses/QueryWithReservedWordResponse.kt
+++ b/Tests/Resources/ExpectedKotlinCode/Responses/QueryWithReservedWordResponse.kt
@@ -1,0 +1,39 @@
+
+package com.shopify.syrup.responses
+
+import com.shopify.foundation.syrupsupport.*
+import com.shopify.syrup.enums.*
+import java.math.BigDecimal
+import org.joda.time.DateTime
+import com.google.gson.JsonObject
+import javax.annotation.Generated
+
+@Generated("com.shopify.syrup")
+data class QueryWithReservedWordResponse(
+
+    /**
+     * Returns a Shop resource corresponding to access token used in request.
+     */
+    val `class`: Class
+) : Response {
+    constructor(jsonObject: JsonObject) : this(
+        `class` = Class(jsonObject.getAsJsonObject("class"))
+    )
+
+        data class Class(
+        /**
+         * Globally unique identifier.
+         */
+        val `return`: ID,
+        /**
+         * The shop's name.
+         */
+        val `fun`: String
+    ) : Response {
+        constructor(jsonObject: JsonObject) : this(
+            `return` = OperationGsonBuilder.gson.fromJson(jsonObject.get("return"), ID::class.java),
+            `fun` = OperationGsonBuilder.gson.fromJson(jsonObject.get("fun"), String::class.java)
+        )
+    }
+
+}

--- a/Tests/Resources/ExpectedSwiftCode/Fragments/TopLevelFragmentWithReservedWordNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Fragments/TopLevelFragmentWithReservedWordNext.swift
@@ -1,0 +1,140 @@
+// Syrup auto-generated file
+import Foundation
+
+public extension MerchantApi {
+struct TopLevelFragmentWithReservedWord: GraphApiResponse, Equatable {
+	// MARK: - Response Fields
+		/// Returns a specific node by ID.
+		public var node: Node?
+
+	// MARK: - Helpers
+	public let __typename: String
+
+	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
+	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+
+	public init(node: Node?) {
+			self.node = node
+			self.__typename = "QueryRoot"
+	}
+
+		// MARK: - Nested Types
+public struct Node: GraphApiResponse, Equatable {
+	public var realized: Realized
+	private var common: BaseNode
+	public var __typename: String
+	public enum Realized: Equatable {
+			case product(Product)
+		case base(BaseNode)
+	}
+	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
+	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+	private enum CodingKeys: String, CodingKey {
+		case __typename = "__typename"
+	}
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		self.__typename = try container.decode(String.self, forKey: .__typename)
+		switch __typename {
+			case "Product":
+				self.realized = .product(try Product(from: decoder))
+		default:
+			self.realized = .base(try BaseNode(from: decoder))
+		}
+		self.common = try BaseNode(from: decoder)
+	}
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: CodingKeys.self)
+		try container.encode(__typename, forKey: .__typename)
+		switch realized {
+			case .product(let value):
+				try value.encode(to: encoder)
+		case .base(let value):
+			try value.encode(to: encoder)
+		}
+	}
+	public init(__typename: String, realized: Realized) {
+		self.__typename = __typename
+		self.realized = realized
+		self.common = BaseNode()
+	}
+public struct Product: GraphApiResponse, Equatable {
+	// MARK: - Response Fields
+		/// Globally unique identifier.
+		public var `var`: GraphID
+	// MARK: - Helpers
+	public let __typename: String
+	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
+	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+	public init(`var`: GraphID) {
+			self.`var` = `var`
+			self.__typename = "Product"
+	}
+}
+public struct BaseNode: GraphApiResponse, Equatable {
+	// MARK: - Response Fields
+	// MARK: - Helpers
+	public let __typename: String
+	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
+	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+	public init() {
+			self.__typename = "Node"
+	}
+}
+}
+}
+}
+
+
+extension MerchantApi.TopLevelFragmentWithReservedWord {
+  static let fragmentSpread = GraphSelections.FragmentSpread(
+    name: "TopLevelFragmentWithReservedWord",
+    typeCondition: .object("QueryRoot"),
+    selectionSet: 
+  [
+  .field(GraphSelections.Field(name: "__typename", alias: nil
+, arguments: 
+  []
+, parentType: .object("QueryRoot"), type: .scalar("String"), selectionSet: 
+  []
+  ))
+  , 
+  .field(GraphSelections.Field(name: "node", alias: nil
+, arguments: 
+  [
+    GraphSelections.Argument(name: "id", value: 
+      .stringValue("")
+)
+  ]
+, parentType: .object("QueryRoot"), type: .interface("Node"), selectionSet: 
+  [
+  .field(GraphSelections.Field(name: "__typename", alias: nil
+, arguments: 
+  []
+, parentType: .interface("Node"), type: .scalar("String"), selectionSet: 
+  []
+  ))
+  , 
+  .inlineFragment(GraphSelections.InlineFragment(typeCondition: .object("Product")
+, selectionSet: 
+  [
+  .field(GraphSelections.Field(name: "__typename", alias: nil
+, arguments: 
+  []
+, parentType: .object("Product"), type: .scalar("String"), selectionSet: 
+  []
+  ))
+  , 
+  .field(GraphSelections.Field(name: "id", alias: "var"
+, arguments: 
+  []
+, parentType: .object("Product"), type: .scalar("ID"), selectionSet: 
+  []
+  ))
+  ]
+  ))
+  ]
+  ))
+  ]
+  )
+}

--- a/Tests/Resources/ExpectedSwiftCode/Fragments/TopLevelFragmentWithReservedWordNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Fragments/TopLevelFragmentWithReservedWordNext.swift
@@ -23,8 +23,17 @@ public struct Node: GraphApiResponse, Equatable {
 	public var realized: Realized
 	private var common: BaseNode
 	public var __typename: String
+	// MARK: - Common Fields
+		/// Globally unique identifier.
+		public var `var`: GraphID {
+			get {
+				return common.`var`
+			}
+			set {
+				common.`var` = newValue
+			}
+		}
 	public enum Realized: Equatable {
-			case product(Product)
 		case base(BaseNode)
 	}
 	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
@@ -36,8 +45,6 @@ public struct Node: GraphApiResponse, Equatable {
 		let container = try decoder.container(keyedBy: CodingKeys.self)
 		self.__typename = try container.decode(String.self, forKey: .__typename)
 		switch __typename {
-			case "Product":
-				self.realized = .product(try Product(from: decoder))
 		default:
 			self.realized = .base(try BaseNode(from: decoder))
 		}
@@ -47,18 +54,16 @@ public struct Node: GraphApiResponse, Equatable {
 		var container = encoder.container(keyedBy: CodingKeys.self)
 		try container.encode(__typename, forKey: .__typename)
 		switch realized {
-			case .product(let value):
-				try value.encode(to: encoder)
 		case .base(let value):
 			try value.encode(to: encoder)
 		}
 	}
-	public init(__typename: String, realized: Realized) {
+	public init(__typename: String, realized: Realized, `var`: GraphID) {
 		self.__typename = __typename
 		self.realized = realized
-		self.common = BaseNode()
+		self.common = BaseNode(var: `var`)
 	}
-public struct Product: GraphApiResponse, Equatable {
+public struct BaseNode: GraphApiResponse, Equatable {
 	// MARK: - Response Fields
 		/// Globally unique identifier.
 		public var `var`: GraphID
@@ -68,16 +73,6 @@ public struct Product: GraphApiResponse, Equatable {
 	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
 	public init(`var`: GraphID) {
 			self.`var` = `var`
-			self.__typename = "Product"
-	}
-}
-public struct BaseNode: GraphApiResponse, Equatable {
-	// MARK: - Response Fields
-	// MARK: - Helpers
-	public let __typename: String
-	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
-	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
-	public init() {
 			self.__typename = "Node"
 	}
 }
@@ -115,23 +110,11 @@ extension MerchantApi.TopLevelFragmentWithReservedWord {
   []
   ))
   , 
-  .inlineFragment(GraphSelections.InlineFragment(typeCondition: .object("Product")
-, selectionSet: 
-  [
-  .field(GraphSelections.Field(name: "__typename", alias: nil
-, arguments: 
-  []
-, parentType: .object("Product"), type: .scalar("String"), selectionSet: 
-  []
-  ))
-  , 
   .field(GraphSelections.Field(name: "id", alias: "var"
 , arguments: 
   []
-, parentType: .object("Product"), type: .scalar("ID"), selectionSet: 
+, parentType: .interface("Node"), type: .scalar("ID"), selectionSet: 
   []
-  ))
-  ]
   ))
   ]
   ))

--- a/Tests/Resources/ExpectedSwiftCode/Queries/QueryWithReservedWordOnInlineFragmentQueryNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Queries/QueryWithReservedWordOnInlineFragmentQueryNext.swift
@@ -1,0 +1,85 @@
+// Syrup auto-generated file
+import Foundation
+
+public extension MerchantApi {
+	struct QueryWithReservedWordOnInlineFragmentQuery: GraphApiQuery, ResponseAssociable, Equatable {
+		// MARK: - Query Variables
+
+		// MARK: - Initializer
+		public init() {
+		}
+
+		// MARK: - Helpers
+
+		public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+
+		private enum CodingKeys: CodingKey {
+		}
+
+		public typealias Response = QueryWithReservedWordOnInlineFragmentResponse
+
+		public let queryString: String = """
+		query QueryWithReservedWordOnInlineFragment { __typename node(id: "123") { __typename id ... on Product { __typename let: title } } }
+		"""
+	}
+}
+
+
+extension MerchantApi.QueryWithReservedWordOnInlineFragmentQuery {
+  public static let operationSelections: GraphSelections.Operation? = GraphSelections.Operation(
+    type: .query("QueryRoot"),
+    selectionSet: 
+  [
+  .field(GraphSelections.Field(name: "__typename", alias: nil
+, arguments: 
+  []
+, parentType: .object("QueryRoot"), type: .scalar("String"), selectionSet: 
+  []
+  ))
+  , 
+  .field(GraphSelections.Field(name: "node", alias: nil
+, arguments: 
+  [
+    GraphSelections.Argument(name: "id", value: 
+      .stringValue("123")
+)
+  ]
+, parentType: .object("QueryRoot"), type: .interface("Node"), selectionSet: 
+  [
+  .field(GraphSelections.Field(name: "__typename", alias: nil
+, arguments: 
+  []
+, parentType: .interface("Node"), type: .scalar("String"), selectionSet: 
+  []
+  ))
+  , 
+  .field(GraphSelections.Field(name: "id", alias: nil
+, arguments: 
+  []
+, parentType: .interface("Node"), type: .scalar("ID"), selectionSet: 
+  []
+  ))
+  , 
+  .inlineFragment(GraphSelections.InlineFragment(typeCondition: .object("Product")
+, selectionSet: 
+  [
+  .field(GraphSelections.Field(name: "__typename", alias: nil
+, arguments: 
+  []
+, parentType: .object("Product"), type: .scalar("String"), selectionSet: 
+  []
+  ))
+  , 
+  .field(GraphSelections.Field(name: "title", alias: "let"
+, arguments: 
+  []
+, parentType: .object("Product"), type: .scalar("String"), selectionSet: 
+  []
+  ))
+  ]
+  ))
+  ]
+  ))
+  ]
+  )
+}

--- a/Tests/Resources/ExpectedSwiftCode/Queries/QueryWithReservedWordQueryNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Queries/QueryWithReservedWordQueryNext.swift
@@ -1,0 +1,69 @@
+// Syrup auto-generated file
+import Foundation
+
+public extension MerchantApi {
+	struct QueryWithReservedWordQuery: GraphApiQuery, ResponseAssociable, Equatable {
+		// MARK: - Query Variables
+
+		// MARK: - Initializer
+		public init() {
+		}
+
+		// MARK: - Helpers
+
+		public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+
+		private enum CodingKeys: CodingKey {
+		}
+
+		public typealias Response = QueryWithReservedWordResponse
+
+		public let queryString: String = """
+		query QueryWithReservedWord { __typename class: shop { __typename return: id func: name } }
+		"""
+	}
+}
+
+
+extension MerchantApi.QueryWithReservedWordQuery {
+  public static let operationSelections: GraphSelections.Operation? = GraphSelections.Operation(
+    type: .query("QueryRoot"),
+    selectionSet: 
+  [
+  .field(GraphSelections.Field(name: "__typename", alias: nil
+, arguments: 
+  []
+, parentType: .object("QueryRoot"), type: .scalar("String"), selectionSet: 
+  []
+  ))
+  , 
+  .field(GraphSelections.Field(name: "shop", alias: "class"
+, arguments: 
+  []
+, parentType: .object("QueryRoot"), type: .object("Shop"), selectionSet: 
+  [
+  .field(GraphSelections.Field(name: "__typename", alias: nil
+, arguments: 
+  []
+, parentType: .object("Shop"), type: .scalar("String"), selectionSet: 
+  []
+  ))
+  , 
+  .field(GraphSelections.Field(name: "id", alias: "return"
+, arguments: 
+  []
+, parentType: .object("Shop"), type: .scalar("ID"), selectionSet: 
+  []
+  ))
+  , 
+  .field(GraphSelections.Field(name: "name", alias: "func"
+, arguments: 
+  []
+, parentType: .object("Shop"), type: .scalar("String"), selectionSet: 
+  []
+  ))
+  ]
+  ))
+  ]
+  )
+}

--- a/Tests/Resources/ExpectedSwiftCode/Responses/QueryWithReservedWordOnInlineFragmentResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/QueryWithReservedWordOnInlineFragmentResponseNext.swift
@@ -1,0 +1,102 @@
+// Syrup auto-generated file
+import Foundation
+
+public extension MerchantApi {
+struct QueryWithReservedWordOnInlineFragmentResponse: GraphApiResponse, Equatable {
+	// MARK: - Response Fields
+		/// Returns a specific node by ID.
+		public var node: Node?
+
+	// MARK: - Helpers
+	public let __typename: String
+
+	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
+	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+
+	public init(node: Node?) {
+			self.node = node
+			self.__typename = "QueryRoot"
+	}
+
+		// MARK: - Nested Types
+public struct Node: GraphApiResponse, Equatable {
+	public var realized: Realized
+	private var common: BaseNode
+	public var __typename: String
+	// MARK: - Common Fields
+		/// Globally unique identifier.
+		public var id: GraphID {
+			get {
+				return common.id
+			}
+			set {
+				common.id = newValue
+			}
+		}
+	public enum Realized: Equatable {
+			case product(Product)
+		case base(BaseNode)
+	}
+	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
+	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+	private enum CodingKeys: String, CodingKey {
+		case __typename = "__typename"
+	}
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		self.__typename = try container.decode(String.self, forKey: .__typename)
+		switch __typename {
+			case "Product":
+				self.realized = .product(try Product(from: decoder))
+		default:
+			self.realized = .base(try BaseNode(from: decoder))
+		}
+		self.common = try BaseNode(from: decoder)
+	}
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: CodingKeys.self)
+		try container.encode(__typename, forKey: .__typename)
+		switch realized {
+			case .product(let value):
+				try value.encode(to: encoder)
+		case .base(let value):
+			try value.encode(to: encoder)
+		}
+	}
+	public init(__typename: String, realized: Realized, id: GraphID) {
+		self.__typename = __typename
+		self.realized = realized
+		self.common = BaseNode(id: id)
+	}
+public struct Product: GraphApiResponse, Equatable {
+	// MARK: - Response Fields
+		/// Globally unique identifier.
+		public var id: GraphID
+		/// The title of the product.
+		public var `let`: String
+	// MARK: - Helpers
+	public let __typename: String
+	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
+	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+	public init(id: GraphID, `let`: String) {
+			self.id = id
+			self.`let` = `let`
+			self.__typename = "Product"
+	}
+}
+public struct BaseNode: GraphApiResponse, Equatable {
+	// MARK: - Response Fields
+		/// Globally unique identifier.
+		public var id: GraphID
+	// MARK: - Helpers
+	public let __typename: String
+	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
+	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+	public init(id: GraphID) {
+			self.id = id
+			self.__typename = "Node"
+	}
+}
+}
+}
+}

--- a/Tests/Resources/ExpectedSwiftCode/Responses/QueryWithReservedWordResponseNext.swift
+++ b/Tests/Resources/ExpectedSwiftCode/Responses/QueryWithReservedWordResponseNext.swift
@@ -1,0 +1,39 @@
+// Syrup auto-generated file
+import Foundation
+
+public extension MerchantApi {
+struct QueryWithReservedWordResponse: GraphApiResponse, Equatable {
+	// MARK: - Response Fields
+		/// Returns a Shop resource corresponding to access token used in request.
+		public var `class`: Class
+
+	// MARK: - Helpers
+	public let __typename: String
+
+	public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
+	public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+
+	public init(`class`: Class) {
+			self.`class` = `class`
+			self.__typename = "QueryRoot"
+	}
+
+		// MARK: - Nested Types
+			public struct Class: GraphApiResponse, Equatable {
+		// MARK: - Response Fields
+			/// Globally unique identifier.
+			public var `return`: GraphID
+			/// The shop's name.
+			public var `func`: String
+		// MARK: - Helpers
+		public let __typename: String
+		public static let customDecoder: JSONDecoder = MerchantApi.customDecoder
+		public static let customEncoder: JSONEncoder = MerchantApi.customEncoder
+		public init(`return`: GraphID, `func`: String) {
+				self.`return` = `return`
+				self.`func` = `func`
+				self.__typename = "Shop"
+		}
+	}
+}
+}

--- a/Tests/Resources/TestOperations/Kotlin/QueryWithReservedWord.graphql
+++ b/Tests/Resources/TestOperations/Kotlin/QueryWithReservedWord.graphql
@@ -1,0 +1,6 @@
+query QueryWithReservedWord {
+  class: shop {
+    return: id
+    fun: name
+  }
+}

--- a/Tests/Resources/TestOperations/Kotlin/QueryWithReservedWordOnInlineFragment.graphql
+++ b/Tests/Resources/TestOperations/Kotlin/QueryWithReservedWordOnInlineFragment.graphql
@@ -1,0 +1,8 @@
+query QueryWithReservedWordOnInlineFragment {
+  node(id:"123") {
+    id
+    ... on Product {
+      val: title
+    }
+  }
+}

--- a/Tests/Resources/TestOperations/Kotlin/TopLevelFragmentWithReservedWord.graphql
+++ b/Tests/Resources/TestOperations/Kotlin/TopLevelFragmentWithReservedWord.graphql
@@ -1,7 +1,5 @@
 fragment TopLevelFragmentWithReservedWord on QueryRoot {
   node(id: "") {
-    ... on Product {
-      var: id
-    }
+    var: id
   }
 }

--- a/Tests/Resources/TestOperations/Kotlin/TopLevelFragmentWithReservedWord.graphql
+++ b/Tests/Resources/TestOperations/Kotlin/TopLevelFragmentWithReservedWord.graphql
@@ -1,0 +1,7 @@
+fragment TopLevelFragmentWithReservedWord on QueryRoot {
+  node(id: "") {
+    ... on Product {
+      var: id
+    }
+  }
+}

--- a/Tests/Resources/TestOperations/Swift/Test.graphql
+++ b/Tests/Resources/TestOperations/Swift/Test.graphql
@@ -513,5 +513,29 @@ query NullableCustomCodedScalar {
 }
 
 subscription Subscription1 {
-	presenceChanged
+  presenceChanged
+}
+
+query QueryWithReservedWord {
+  class: shop {
+    return: id
+    func: name
+  }
+}
+
+query QueryWithReservedWordOnInlineFragment {
+  node(id:"123") {
+    id
+    ... on Product {
+      let: title
+    }
+  }
+}
+
+fragment TopLevelFragmentWithReservedWord on QueryRoot {
+  node(id: "") {
+    ... on Product {
+      var: id
+    }
+  }
 }

--- a/Tests/Resources/TestOperations/Swift/Test.graphql
+++ b/Tests/Resources/TestOperations/Swift/Test.graphql
@@ -534,8 +534,6 @@ query QueryWithReservedWordOnInlineFragment {
 
 fragment TopLevelFragmentWithReservedWord on QueryRoot {
   node(id: "") {
-    ... on Product {
-      var: id
-    }
+    var: id
   }
 }


### PR DESCRIPTION
## Update

Resolves https://github.com/Shopify/syrup/issues/29
Escapes reserved words used as fields for both, Kotlin and Swift

## What is this doing
For Swift in the generated response file:
- Escape property declaration
- Espape argument declaration on `init` (Not was not needed, but it gives a warning if the reserved word is `let` or `var`)
- Escape `self.'field'` on init. This is not needed all the time but added it anyways to handle edge cases like a property named `self`.
- Escape the parameter being used on `init`

For Kotlin in the generated response file:
- Escape property declaration
- Escape property set on init. 

**Notes:**
This is also fixing a typo for the reserved word `class` on Kotlin, and also removing `field` as a reserved word. There are other reserved words that can be used as a property name in Kotlin like `external` and `set`; I think it would be worth considering removing some of these later.

## Tophat instructions
- Look at the changes
- Examine the generated subscription models
- Will the Swift and Kotlin models compile (I checked in XCode and Android Studio and it seems they do)?