### PR TITLE
Fix header & support header positions for TypeScript

### DIFF
--- a/Templates/TypeScript/GraphApi.stencil
+++ b/Templates/TypeScript/GraphApi.stencil
@@ -1,9 +1,5 @@
-{% if supportFilesHeader %}import { SimpleDocument } from "graphql-typed"
-{{ supportFilesHeader }}
+{% if supportFilesHeader %}{{ supportFilesHeader }}\n{% endif %}import { SimpleDocument } from "graphql-typed"
 
-{% else %}import { SimpleDocument } from "graphql-typed"
-
-{% endif %}
 export type ID = string
 
 export interface GraphSelection {

--- a/Templates/TypeScript/Helpers/Imports.stencil
+++ b/Templates/TypeScript/Helpers/Imports.stencil
@@ -1,5 +1,4 @@
-import { ID, GraphSelection, SyrupOperation, copyWithTypeCondition } from "../GraphApi"
-{{ header }}
+{% if header %}{{ header }}\n{% endif %}import { ID, GraphSelection, SyrupOperation, copyWithTypeCondition } from "../GraphApi"
 {% if allReferencedFragments and allReferencedFragments.count > 0 %}import {
   {% for name in allReferencedFragments %}{{ name }}FragmentData,
   {{ name|lowercasedFirstLetter }}Selections,


### PR DESCRIPTION
Header & support header positions fall under the imports for the generated files. This PR moves the `header` and `supportHeader` above the imports.