### PR TITLE
Updates `TypeScript` sample with latest changes to selection model.

### DIFF
--- a/samples/typescript/src/data/syrup/Fragments/MovieFragment.ts
+++ b/samples/typescript/src/data/syrup/Fragments/MovieFragment.ts
@@ -26,37 +26,21 @@ export const movieFragmentSelections: GraphSelection[] = ([
   {
     name: "__typename",
     type: { name: "String", definedType: "Scalar" },
-    arguments: {},
-    passedGID: null,
     typeCondition: { name: "Film", definedType: "Object" },
-    directive: null,
-    selections: ([] as GraphSelection[])
   }, 
   {
     name: "title",
     type: { name: "String", definedType: "Scalar" },
-    arguments: {},
-    passedGID: null,
     typeCondition: { name: "Film", definedType: "Object" },
-    directive: null,
-    selections: ([] as GraphSelection[])
   }, 
   {
     name: "director",
     type: { name: "String", definedType: "Scalar" },
-    arguments: {},
-    passedGID: null,
     typeCondition: { name: "Film", definedType: "Object" },
-    directive: null,
-    selections: ([] as GraphSelection[])
   }, 
   {
     name: "openingCrawl",
     type: { name: "String", definedType: "Scalar" },
-    arguments: {},
-    passedGID: null,
     typeCondition: { name: "Film", definedType: "Object" },
-    directive: null,
-    selections: ([] as GraphSelection[])
   }
 ] as GraphSelection[])

--- a/samples/typescript/src/data/syrup/GraphApi.ts
+++ b/samples/typescript/src/data/syrup/GraphApi.ts
@@ -4,12 +4,13 @@ export type ID = string
 
 export interface GraphSelection {
   name: string
-  arguments: Record<string, any>
   type: TypeDefinition
-  passedGID: string | null
-  typeCondition: TypeDefinition | null
-  directive: ConditionalDirective | null
-  selections: GraphSelection[]
+  typeCondition: TypeDefinition
+  alias?: string
+  arguments?: Record<string, any>
+  passedGID?: string
+  directive?: ConditionalDirective
+  selections?: GraphSelection[]
 }
 
 export interface TypeDefinition {

--- a/samples/typescript/src/data/syrup/Queries/FilmsQuery.ts
+++ b/samples/typescript/src/data/syrup/Queries/FilmsQuery.ts
@@ -38,62 +38,37 @@ const document: SyrupOperation<FilmsQueryData, {}> = {
     {
       name: "__typename",
       type: { name: "String", definedType: "Scalar" },
-      arguments: {},
-      passedGID: null,
       typeCondition: { name: "Root", definedType: "Object" },
-      directive: null,
-      selections: ([] as GraphSelection[])
     }, 
     {
       name: "allFilms",
       type: { name: "FilmsConnection", definedType: "Object" },
-      arguments: {},
-      passedGID: null,
       typeCondition: { name: "Root", definedType: "Object" },
-      directive: null,
       selections: ([
         {
           name: "__typename",
           type: { name: "String", definedType: "Scalar" },
-          arguments: {},
-          passedGID: null,
           typeCondition: { name: "FilmsConnection", definedType: "Object" },
-          directive: null,
-          selections: ([] as GraphSelection[])
         }, 
         {
           name: "edges",
           type: { name: "FilmsEdge", definedType: "Object" },
-          arguments: {},
-          passedGID: null,
           typeCondition: { name: "FilmsConnection", definedType: "Object" },
-          directive: null,
           selections: ([
             {
               name: "__typename",
               type: { name: "String", definedType: "Scalar" },
-              arguments: {},
-              passedGID: null,
               typeCondition: { name: "FilmsEdge", definedType: "Object" },
-              directive: null,
-              selections: ([] as GraphSelection[])
             }, 
             {
               name: "node",
               type: { name: "Film", definedType: "Object" },
-              arguments: {},
-              passedGID: null,
               typeCondition: { name: "FilmsEdge", definedType: "Object" },
-              directive: null,
               selections: ([
                 {
                   name: "__typename",
                   type: { name: "String", definedType: "Scalar" },
-                  arguments: {},
-                  passedGID: null,
                   typeCondition: { name: "Film", definedType: "Object" },
-                  directive: null,
-                  selections: ([] as GraphSelection[])
                 }
               ] as GraphSelection[]).concat(movieFragmentSelections).map(x => copyWithTypeCondition(x, { name: "Film", definedType: "Object" }))
             }


### PR DESCRIPTION
Updates `TypeScript` sample with latest changes to selection model. Forgot to re-generate the models from latest PRs.