### PR TITLE
Make `Swift` selection elements `Equatable`.

### DIFF
--- a/Templates/Swift/GraphApi.stencil
+++ b/Templates/Swift/GraphApi.stencil
@@ -137,7 +137,7 @@ open class BaseCustomScalarResolver {
 }
 
 public enum GraphSelections {
-	public struct Operation {
+	public struct Operation: Equatable {
 		public let type: OperationType
 		public let selectionSet: [Selection]
 
@@ -147,7 +147,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum OperationType {
+	public enum OperationType: Equatable {
 		case mutation(String)
 		case query(String)
 		case subscription(String)
@@ -159,7 +159,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum Selection {
+	public enum Selection: Equatable {
 		case field(Field)
 		case fragmentSpread(FragmentSpread, conditionalDirective: ConditionalDirective?)
 		case inlineFragment(InlineFragment)
@@ -169,7 +169,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public struct Field {
+	public struct Field: Equatable {
 		public let name: String
 		public let alias: String?
 		public let conditionalDirective: ConditionalDirective?
@@ -189,12 +189,12 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum ConditionalDirective {
+	public enum ConditionalDirective: Equatable {
 		case skip(ArgumentValue)
 		case include(ArgumentValue)
 	}
 
-	public struct Argument {
+	public struct Argument: Equatable {
 		public let name: String
 		public let value: ArgumentValue
 
@@ -204,7 +204,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public struct FragmentSpread {
+	public struct FragmentSpread: Equatable {
 		public let name: String
 		public let typeCondition: TypeCondition
 		public let selectionSet: [Selection]
@@ -216,7 +216,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public struct InlineFragment {
+	public struct InlineFragment: Equatable {
 		public let typeCondition: TypeCondition
 		public let conditionalDirective: ConditionalDirective?
 		public let selectionSet: [Selection]
@@ -228,14 +228,14 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum TypeCondition {
+	public enum TypeCondition: Equatable {
 		case object(String)
 		case interface(String)
 		case union(String)
 		case scalar(String)
 	}
 
-	public enum ArgumentValue {
+	public enum ArgumentValue: Equatable {
 		case variable(String)
 		case intValue(Int)
 		case floatValue(Float)
@@ -247,7 +247,7 @@ public enum GraphSelections {
 		case objectValue([ObjectField])
 	}
 
-	public struct ObjectField {
+	public struct ObjectField: Equatable {
 		public let name: String
 		public let value: ArgumentValue
 

--- a/Tests/Resources/ExpectedSwiftCode/GraphApi.swift
+++ b/Tests/Resources/ExpectedSwiftCode/GraphApi.swift
@@ -138,7 +138,7 @@ open class BaseCustomScalarResolver {
 }
 
 public enum GraphSelections {
-	public struct Operation {
+	public struct Operation: Equatable {
 		public let type: OperationType
 		public let selectionSet: [Selection]
 
@@ -148,7 +148,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum OperationType {
+	public enum OperationType: Equatable {
 		case mutation(String)
 		case query(String)
 		case subscription(String)
@@ -160,7 +160,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum Selection {
+	public enum Selection: Equatable {
 		case field(Field)
 		case fragmentSpread(FragmentSpread, conditionalDirective: ConditionalDirective?)
 		case inlineFragment(InlineFragment)
@@ -170,7 +170,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public struct Field {
+	public struct Field: Equatable {
 		public let name: String
 		public let alias: String?
 		public let conditionalDirective: ConditionalDirective?
@@ -190,12 +190,12 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum ConditionalDirective {
+	public enum ConditionalDirective: Equatable {
 		case skip(ArgumentValue)
 		case include(ArgumentValue)
 	}
 
-	public struct Argument {
+	public struct Argument: Equatable {
 		public let name: String
 		public let value: ArgumentValue
 
@@ -205,7 +205,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public struct FragmentSpread {
+	public struct FragmentSpread: Equatable {
 		public let name: String
 		public let typeCondition: TypeCondition
 		public let selectionSet: [Selection]
@@ -217,7 +217,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public struct InlineFragment {
+	public struct InlineFragment: Equatable {
 		public let typeCondition: TypeCondition
 		public let conditionalDirective: ConditionalDirective?
 		public let selectionSet: [Selection]
@@ -229,14 +229,14 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum TypeCondition {
+	public enum TypeCondition: Equatable {
 		case object(String)
 		case interface(String)
 		case union(String)
 		case scalar(String)
 	}
 
-	public enum ArgumentValue {
+	public enum ArgumentValue: Equatable {
 		case variable(String)
 		case intValue(Int)
 		case floatValue(Float)
@@ -248,7 +248,7 @@ public enum GraphSelections {
 		case objectValue([ObjectField])
 	}
 
-	public struct ObjectField {
+	public struct ObjectField: Equatable {
 		public let name: String
 		public let value: ArgumentValue
 

--- a/samples/swift/Sample.playground/Sources/Generated/GraphApi.swift
+++ b/samples/swift/Sample.playground/Sources/Generated/GraphApi.swift
@@ -138,7 +138,7 @@ open class BaseCustomScalarResolver {
 }
 
 public enum GraphSelections {
-	public struct Operation {
+	public struct Operation: Equatable {
 		public let type: OperationType
 		public let selectionSet: [Selection]
 
@@ -148,7 +148,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum OperationType {
+	public enum OperationType: Equatable {
 		case mutation(String)
 		case query(String)
 		public var name: String {
@@ -159,7 +159,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum Selection {
+	public enum Selection: Equatable {
 		case field(Field)
 		case fragmentSpread(FragmentSpread, conditionalDirective: ConditionalDirective?)
 		case inlineFragment(InlineFragment)
@@ -169,7 +169,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public struct Field {
+	public struct Field: Equatable {
 		public let name: String
 		public let alias: String?
 		public let conditionalDirective: ConditionalDirective?
@@ -189,12 +189,12 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum ConditionalDirective {
+	public enum ConditionalDirective: Equatable {
 		case skip(ArgumentValue)
 		case include(ArgumentValue)
 	}
 
-	public struct Argument {
+	public struct Argument: Equatable {
 		public let name: String
 		public let value: ArgumentValue
 
@@ -204,7 +204,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public struct FragmentSpread {
+	public struct FragmentSpread: Equatable {
 		public let name: String
 		public let typeCondition: TypeCondition
 		public let selectionSet: [Selection]
@@ -216,7 +216,7 @@ public enum GraphSelections {
 		}
 	}
 
-	public struct InlineFragment {
+	public struct InlineFragment: Equatable {
 		public let typeCondition: TypeCondition
 		public let conditionalDirective: ConditionalDirective?
 		public let selectionSet: [Selection]
@@ -228,14 +228,14 @@ public enum GraphSelections {
 		}
 	}
 
-	public enum TypeCondition {
+	public enum TypeCondition: Equatable {
 		case object(String)
 		case interface(String)
 		case union(String)
 		case scalar(String)
 	}
 
-	public enum ArgumentValue {
+	public enum ArgumentValue: Equatable {
 		case variable(String)
 		case intValue(Int)
 		case floatValue(Float)
@@ -247,7 +247,7 @@ public enum GraphSelections {
 		case objectValue([ObjectField])
 	}
 
-	public struct ObjectField {
+	public struct ObjectField: Equatable {
 		public let name: String
 		public let value: ArgumentValue
 


### PR DESCRIPTION
Resolves #37 

Make `Swift` selection elements conform to `Equatable`.