### PR TITLE
Support building with Xcode 13

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,10 +17,15 @@ jobs:
   Linux:
 
     runs-on: ubuntu-latest
-    container: swift:5.3.1
+    container: swift:5.5.0
 
     steps:
     - uses: actions/checkout@v1
+    - name: Install packages
+      shell: bash
+      run: |
+        apt-get update --assume-yes
+        apt-get install --assume-yes libsqlite3-dev
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
         }
       },
       {
@@ -24,17 +24,17 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
-          "version": "0.9.2"
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
         }
       },
       {
         "package": "Stencil",
-        "repositoryURL": "https://github.com/stencilproject/Stencil.git",
+        "repositoryURL": "https://github.com/jaredh/Stencil",
         "state": {
-          "branch": null,
-          "revision": "c7dbba41a5cf7ab5a5bdfb5f7855170d05c5f031",
-          "version": "0.13.0"
+          "branch": "master",
+          "revision": "cd3c6293a824882daa96f24c6e6c46dc633ecab4",
+          "version": null
         }
       },
       {
@@ -47,12 +47,12 @@
         }
       },
       {
-        "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "235aacc514cb81a6881364b0fedcb3dd083228f3",
-          "version": "0.3.0"
+          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
+          "version": "0.2.3"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
-          "version": "2.0.0"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
 	],
 	dependencies: [
 		.package(
-			url: "https://github.com/stencilproject/Stencil.git",
-			.exact("0.13.0")
+			url: "https://github.com/jaredh/Stencil",
+			.branch("master")
 		),
 		.package(
 			url: "https://github.com/JohnSundell/files",
@@ -28,11 +28,11 @@ let package = Package(
 		),
 		.package(
 			url: "https://github.com/jpsim/Yams.git",
-			from: "2.0.0"
+			from: "4.0.6"
 		),
 		.package(
-			url: "https://github.com/apple/swift-package-manager.git",
-			.exact("0.3.0")
+			url: "https://github.com/apple/swift-tools-support-core.git",
+			.exact("0.2.3")
 		),
 		.package(
 			url: "https://github.com/Shopify/SwiftGraphQLParser",
@@ -46,11 +46,11 @@ let package = Package(
 	targets: [
 		.target(
 			name: "Syrup",
-			dependencies: ["SyrupCore", "Utility"]
+			dependencies: ["SyrupCore", "SwiftToolsSupport"]
 		),
 		.target(
 			name: "SyrupCore",
-			dependencies: ["Stencil", "Files", "Yams", "Utility", "SwiftGraphQLParser", "Crypto"]
+			dependencies: ["Stencil", "Files", "Yams", "SwiftToolsSupport", "SwiftGraphQLParser", "Crypto"]
 		),
 		.testTarget(
 			name: "SyrupTests",

--- a/Sources/Syrup/Syrup.swift
+++ b/Sources/Syrup/Syrup.swift
@@ -22,10 +22,10 @@
  * THE SOFTWARE.
  */
 
-import Basic
+import TSCBasic
 import Foundation
 import SyrupCore
-import Utility
+import TSCUtility
 import Yams
 
 class Syrup {
@@ -201,7 +201,7 @@ class Syrup {
 				}
 				
 				guard Arguments.isValidTemplate(absoluteTemplatePath) else {
-					fatalError("Cannot read template file at path \(absoluteTemplatePath.asString)")
+					fatalError("Cannot read template file at path \(absoluteTemplatePath.pathString)")
 				}
 				options.template = absoluteTemplatePath
 			}
@@ -257,20 +257,20 @@ class Syrup {
 				print("\(Syrup.version)", to: &stdoutStream)
 				stdoutStream.flush()
 			} else {
-				let projectUrl = URL(fileURLWithPath: syrupArgs.project.asString)
+				let projectUrl = URL(fileURLWithPath: syrupArgs.project.pathString)
 				let project = try YAMLDecoder().decode(ProjectSpec.self, from: projectUrl, userInfo: [:])
-				let schemaUrl = URL(fileURLWithPath: syrupArgs.schema.asString)
+				let schemaUrl = URL(fileURLWithPath: syrupArgs.schema.pathString)
 				var schema = try YAMLDecoder().decode(SchemaSpec.self, from: schemaUrl, userInfo: [:])
 				if let overridenSchema = syrupArgs.overridenSchema {
 					schema.location = overridenSchema
 				}
-				let template = try TemplateSpec(location: syrupArgs.template.asString)
+				let template = try TemplateSpec(location: syrupArgs.template.pathString)
 				let config = SyrupCore.Config(
 					shouldGenerateModels: syrupArgs.shouldGenerateModels,
 					shouldGenerateSupportFiles: syrupArgs.shouldGenerateSupportFiles,
-					queries: syrupArgs.queries.asString,
-					destination: syrupArgs.destination.asString,
-					supportFilesDestination: syrupArgs.supportFilesDestination.asString,
+					queries: syrupArgs.queries.pathString,
+					destination: syrupArgs.destination.pathString,
+					supportFilesDestination: syrupArgs.supportFilesDestination.pathString,
 					template: template,
 					project: project,
 					schema: schema,

--- a/Sources/SyrupCore/Config.swift
+++ b/Sources/SyrupCore/Config.swift
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-import Basic
+import TSCBasic
 import Foundation
 
 public struct Config {

--- a/Sources/SyrupCore/Reporter/Reporter.swift
+++ b/Sources/SyrupCore/Reporter/Reporter.swift
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-import Basic
+import TSCBasic
 import Files
 import Foundation
 import SwiftGraphQLParser
@@ -122,7 +122,7 @@ public final class Reporter {
 		
 		// Output to console, report.yml and report.md
 		if let outputReportPath = config.deprecationReport {
-			let folder = try Folder(path: outputReportPath.asString)
+			let folder = try Folder(path: outputReportPath.pathString)
 			
 			var mdReport = ""
 			
@@ -137,9 +137,9 @@ public final class Reporter {
 				mdReport += "\n"+"DEPRECATED \(typename) FIELDS\n".mdH2()
 			}
 			
-			func outputDeprecated(element: (key: String, date: Date)) {
-				print("\t\t\(dateFormatter.string(from: element.date))\t\(element.key)".ansiExpiryFlag(element.date))
-				mdReport += "\(dateFormatter.string(from: element.date))\t`\(element.key)`".mdExpiryFlag(element.date) + "\n" // .todo()
+			func outputDeprecated(element: (key: String, value: Date)) {
+				print("\t\t\(dateFormatter.string(from: element.value))\t\(element.key)".ansiExpiryFlag(element.value))
+				mdReport += "\(dateFormatter.string(from: element.value))\t`\(element.key)`".mdExpiryFlag(element.value) + "\n" // .todo()
 			}
 			
 			func outputRemoved(element: (key: String, date: Date)) {

--- a/Sources/SyrupCore/Stencil Extensions/CallMacroNode.swift
+++ b/Sources/SyrupCore/Stencil Extensions/CallMacroNode.swift
@@ -59,7 +59,7 @@ class MacroNode: NodeType {
 	let token: Token?
 	
 	class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
-		let components = token.components()
+		let components = token.components
 		guard components.count >= 2 else {
 			throw TemplateSyntaxError("'macro' tag takes at least one argument, the name of the variable to set.")
 		}
@@ -94,7 +94,7 @@ class CallNode: NodeType {
 	let token: Token?
 	
 	class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
-		let components = token.components()
+		let components = token.components
 		guard components.count >= 2 else {
 			throw TemplateSyntaxError("'call' tag takes at least one argument, the name of the block to call.")
 		}

--- a/Sources/SyrupCore/Stencil Extensions/MapNode.swift
+++ b/Sources/SyrupCore/Stencil Extensions/MapNode.swift
@@ -32,7 +32,7 @@ class MapNode: NodeType {
 	let token: Token?
 	
 	class func parse(parser: TokenParser, token: Token) throws -> NodeType {
-		let components = token.components()
+		let components = token.components
 		
 		func hasToken(_ token: String, at index: Int) -> Bool {
 			components.indices ~= index + 1 && components[index] == token

--- a/Sources/SyrupCore/Stencil Extensions/WithNode.swift
+++ b/Sources/SyrupCore/Stencil Extensions/WithNode.swift
@@ -27,7 +27,7 @@ import Stencil
 
 final class WithNode: NodeType {
 	class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
-		let components = token.components()
+		let components = token.components
 		
 		guard components.count == 4 && components[2] == "as" else {
 			throw TemplateSyntaxError("'\(components[0])' statements should use the following '\(components[0]) <variable> as <name>' `\(token.contents)`.")

--- a/Sources/SyrupCore/Utilities/Synchronized.swift
+++ b/Sources/SyrupCore/Utilities/Synchronized.swift
@@ -23,7 +23,7 @@
  */
 
 import Foundation
-import Basic
+import TSCBasic
 
 struct Synchronized<T> {
 	private let lock = Lock()


### PR DESCRIPTION
Updates Syrup to build on the latest Xcode toolchain.

Stencil has not shipped a release supporting Xcode 13 yet so I've forked it and will use that until an official release is made. Changes are strictly bumping two of it's dependencies, Spectre and PathKit, to Xcode 13 compatible releases.

Migrated from `swift-package-manager` to `swift-tools-support-core`, and updated Basic references to reflect the renamed package. This new package also has a dependency on libsqlite3 which unfortunately isn't available in the stock Swift docker images, so we're not installing what's required through Apt.