### PR TITLE
Include SwiftToolsSupport in syrup binary

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,11 +46,11 @@ let package = Package(
 	targets: [
 		.target(
 			name: "Syrup",
-			dependencies: ["SyrupCore", "SwiftToolsSupport"]
+			dependencies: ["SyrupCore", "SwiftToolsSupport-auto"]
 		),
 		.target(
 			name: "SyrupCore",
-			dependencies: ["Stencil", "Files", "Yams", "SwiftToolsSupport", "SwiftGraphQLParser", "Crypto"]
+			dependencies: ["Stencil", "Files", "Yams", "SwiftToolsSupport-auto", "SwiftGraphQLParser", "Crypto"]
 		),
 		.testTarget(
 			name: "SyrupTests",


### PR DESCRIPTION
https://github.com/Shopify/syrup/pull/53 added support for building with Xcode 13, however the addition of `SwiftToolsSupport` was not properly linked. When building and running with SwiftPM, it had SwiftToolsSupport in it's path but when building with Mint it was excluded, resulting in an error like this

```
dyld: Library not loaded: @rpath/libSwiftToolsSupport.dylib
  Referenced from: /usr/local/lib/mint/packages/github.com_Shopify_Syrup/build/xcode-13/Syrup
  Reason: image not found
```

This specifies the `SwiftToolsSupport` dependency with `-auto` to include it in the binary.