### PR TITLE
[TS] Fix alias not being copied from fragments.

### DIFF
--- a/Templates/TypeScript/GraphApi.stencil
+++ b/Templates/TypeScript/GraphApi.stencil
@@ -34,12 +34,7 @@ export const copyWithTypeCondition: (
   typeCondition: TypeDefinition | null
 ) => GraphSelection = (selection, typeCondition) => {
   return {
-    name: selection.name,
-    arguments: selection.arguments,
-    type: selection.type,
-    passedGID: selection.passedGID,
+    ...selection,
     typeCondition: typeCondition,
-    directive: selection.directive,
-    selections: selection.selections
   }
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/GraphApi.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/GraphApi.ts
@@ -35,12 +35,7 @@ export const copyWithTypeCondition: (
   typeCondition: TypeDefinition | null
 ) => GraphSelection = (selection, typeCondition) => {
   return {
-    name: selection.name,
-    arguments: selection.arguments,
-    type: selection.type,
-    passedGID: selection.passedGID,
+    ...selection,
     typeCondition: typeCondition,
-    directive: selection.directive,
-    selections: selection.selections
   }
 }


### PR DESCRIPTION
Fix alias not being copied from fragments when using `copyWithTypeCondition`.