### PR TITLE
Fix input objects in OperationVisitor

### DIFF
--- a/Sources/SyrupCore/GraphQL/OperationVisitor.swift
+++ b/Sources/SyrupCore/GraphQL/OperationVisitor.swift
@@ -274,6 +274,7 @@ final class OperationVisitor: GraphQLBaseVisitor {
 	}
 	
 	override func visitObjectField(objectField: SwiftGraphQLParser.ObjectField) {
+		updateContextCounts()
 		valueContext.push(.objectField)
 		currentOperationContents += "\(objectField.name): "
 	}
@@ -296,9 +297,11 @@ final class OperationVisitor: GraphQLBaseVisitor {
 		valueContext.push(.object)
 		objectFieldsSize = objectValue.count
 		objectFieldCount = 0
+		currentOperationContents += valuePrefix()
 	}
 	
 	override func exitObjectValue(objectValue: [SwiftGraphQLParser.ObjectField]) {
+		currentOperationContents += valueSuffix()
 		valueContext.pop()
 	}
 	


### PR DESCRIPTION
While working on another PR, I noticed that Syrup was crashing when trying to parse fields that take an input object as an argument.

For example:
```graphql
fragment ImageUrl on Image {
  transformedSrc: url(transform: { maxWidth: 1024, maxHeight: 768 })
}
```
```
Unterminated argument list starting at line: 3 column: 21 associated with the following input:
 ✓	fragment ImageUrl on Image {
 ✓	__typename
💥	transformedSrc: url(transform: maxWidth: 1024maxHeight: 768)
```
Notice how the `transform:` argument is missing the `{}` and commas between values. I narrowed the bug down to `OperationVisitor` where `valuePrefix` and `valueSuffix` were not being called properly for object fields.

Fixes https://github.com/Shopify/syrup/issues/47