### PR TITLE
Fix cyclic imports in `TypeScript` fragments

### DIFF
--- a/Sources/SyrupCore/Generator/TypeScript/TypeScriptRenderer.swift
+++ b/Sources/SyrupCore/Generator/TypeScript/TypeScriptRenderer.swift
@@ -84,6 +84,7 @@ final class TypeScriptRenderer: Renderer {
 			fields: fields,
 			fragmentSpreads: fragmentSpreads,
 			extras: [
+				"isFragment": true,
 				"allReferencedFragments": referencedImports.fragments,
 				"allReferencedEnums": referencedImports.enums,
 				"selections": fragment.selectionSet
@@ -107,6 +108,7 @@ final class TypeScriptRenderer: Renderer {
 			collectedFields: collectedFields,
 			groupedFragmentSpreads: groupedFragmentSpreads,
 			extras: [
+				"isFragment": true,
 				"allReferencedFragments": referencedImports.fragments,
 				"allReferencedEnums": referencedImports.enums,
 				"selections": fragment.selectionSet

--- a/Templates/TypeScript/Helpers/ImportFragments.stencil
+++ b/Templates/TypeScript/Helpers/ImportFragments.stencil
@@ -1,0 +1,12 @@
+{% macro renderFragmentsFromBarrel allReferencedFragments %}import {
+  {% for name in allReferencedFragments %}{{ name }}FragmentData,
+  {{ name|lowercasedFirstLetter }}Selections,
+  {% endfor %}
+} from "../Fragments"
+{% endmacro %}
+{% macro renderFragmentsLocally allReferencedFragments %}{% for name in allReferencedFragments %}import {
+  {{ name }}FragmentData,
+  {{ name|lowercasedFirstLetter }}Selections,
+} from "./{{ name }}"
+{% endfor %}{% endmacro %}
+{% if isFragment %}{% call renderFragmentsLocally allReferencedFragments %}{% else %}{% call renderFragmentsFromBarrel allReferencedFragments %}{% endif %}

--- a/Templates/TypeScript/Helpers/Imports.stencil
+++ b/Templates/TypeScript/Helpers/Imports.stencil
@@ -1,9 +1,5 @@
 import { ID, GraphSelection, SyrupOperation, copyWithTypeCondition } from "../GraphApi"
-{% if allReferencedFragments and allReferencedFragments.count > 0 %}import {
-  {% for name in allReferencedFragments %}{{ name }}FragmentData,
-  {{ name|lowercasedFirstLetter }}Selections,
-  {% endfor %}
-} from "../Fragments"{% endif %}
+{% if allReferencedFragments and allReferencedFragments.count > 0 %}{% include "Helpers/ImportFragments.stencil" %}{% endif %}
 {% if allReferencedInputTypes and allReferencedInputTypes.count > 0 %}import {
   {% for name in allReferencedInputTypes %}{{ name }},
   {% endfor %}

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventAlert.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventAlert.ts
@@ -1,0 +1,33 @@
+// Syrup auto-generated file
+
+import { ID, GraphSelection, SyrupOperation, copyWithTypeCondition } from "../GraphApi"
+
+export namespace EventAlertFragmentData {
+  export interface Other {
+    __typename: '';
+  }
+
+  export interface _BaseFields_ {
+
+    /**
+     * Whether the event is critical.
+     */
+    criticalAlert: boolean;
+  }
+}
+
+export type EventAlertFragmentData = EventAlertFragmentData.Other
+
+export const eventAlertSelections: GraphSelection[] = ([
+  {
+    name: "__typename",
+    type: { name: "String", definedType: "Scalar" },
+    typeCondition: { name: "Event", definedType: "Interface" },
+  }, 
+  {
+    name: "criticalAlert",
+    type: { name: "Boolean", definedType: "Scalar" },
+    typeCondition: { name: "Event", definedType: "Interface" },
+  }
+] as GraphSelection[])
+

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventAttributeFields.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventAttributeFields.ts
@@ -1,0 +1,43 @@
+// Syrup auto-generated file
+
+import { ID, GraphSelection, SyrupOperation, copyWithTypeCondition } from "../GraphApi"
+
+export namespace EventAttributeFieldsFragmentData {
+  export interface Other {
+    __typename: '';
+  }
+
+  export interface _BaseFields_ {
+
+    /**
+     * Whether the event was created by an app.
+     */
+    attributeToApp: boolean;
+
+    /**
+     * Whether the event was caused by an admin user.
+     */
+    attributeToUser: boolean;
+  }
+}
+
+export type EventAttributeFieldsFragmentData = EventAttributeFieldsFragmentData.Other
+
+export const eventAttributeFieldsSelections: GraphSelection[] = ([
+  {
+    name: "__typename",
+    type: { name: "String", definedType: "Scalar" },
+    typeCondition: { name: "Event", definedType: "Interface" },
+  }, 
+  {
+    name: "attributeToApp",
+    type: { name: "Boolean", definedType: "Scalar" },
+    typeCondition: { name: "Event", definedType: "Interface" },
+  }, 
+  {
+    name: "attributeToUser",
+    type: { name: "Boolean", definedType: "Scalar" },
+    typeCondition: { name: "Event", definedType: "Interface" },
+  }
+] as GraphSelection[])
+

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventPreviewInfo.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventPreviewInfo.ts
@@ -1,0 +1,43 @@
+// Syrup auto-generated file
+
+import { ID, GraphSelection, SyrupOperation, copyWithTypeCondition } from "../GraphApi"
+
+export namespace EventPreviewInfoFragmentData {
+  export interface Other {
+    __typename: '';
+  }
+
+  export interface _BaseFields_ {
+
+    /**
+     * The date and time when the event was created.
+     */
+    createdAt: string;
+
+    /**
+     * Human readable text that describes the event.
+     */
+    message: string;
+  }
+}
+
+export type EventPreviewInfoFragmentData = EventPreviewInfoFragmentData.Other
+
+export const eventPreviewInfoSelections: GraphSelection[] = ([
+  {
+    name: "__typename",
+    type: { name: "String", definedType: "Scalar" },
+    typeCondition: { name: "Event", definedType: "Interface" },
+  }, 
+  {
+    name: "createdAt",
+    type: { name: "DateTime", definedType: "Scalar" },
+    typeCondition: { name: "Event", definedType: "Interface" },
+  }, 
+  {
+    name: "message",
+    type: { name: "FormattedString", definedType: "Scalar" },
+    typeCondition: { name: "Event", definedType: "Interface" },
+  }
+] as GraphSelection[])
+

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/TimelineFragment.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/TimelineFragment.ts
@@ -1,6 +1,18 @@
 // Syrup auto-generated file
 
 import { ID, GraphSelection, SyrupOperation, copyWithTypeCondition } from "../GraphApi"
+import {
+  EventPreviewInfoFragmentData,
+  eventPreviewInfoSelections,
+} from "./EventPreviewInfo"
+import {
+  EventAttributeFieldsFragmentData,
+  eventAttributeFieldsSelections,
+} from "./EventAttributeFields"
+import {
+  EventAlertFragmentData,
+  eventAlertSelections,
+} from "./EventAlert"
 
 export namespace TimelineFragmentFragmentData {
   export interface PageInfo {
@@ -68,31 +80,11 @@ export namespace TimelineFragmentFragmentData {
      */
     attachments: EdgesNodeCommentEventAttachments[];
   }
-  export interface EdgesNode_BaseFields_ {
+  export interface EdgesNode_BaseFields_ extends EventPreviewInfoFragmentData._BaseFields_, EventAttributeFieldsFragmentData._BaseFields_, EventAlertFragmentData._BaseFields_ {
     /**
      * Globally unique identifier.
      */
     id: ID;
-    /**
-     * The date and time when the event was created.
-     */
-    createdAt: string;
-    /**
-     * Human readable text that describes the event.
-     */
-    message: string;
-    /**
-     * Whether the event was created by an app.
-     */
-    attributeToApp: boolean;
-    /**
-     * Whether the event was caused by an admin user.
-     */
-    attributeToUser: boolean;
-    /**
-     * Whether the event is critical.
-     */
-    criticalAlert: boolean;
   }
   export type EdgesNode = EdgesNode_BaseFields_ & (EdgesNodeCommentEvent | EdgesNodeOther)
   export interface Edges {
@@ -176,31 +168,6 @@ export const timelineFragmentSelections: GraphSelection[] = ([
             typeCondition: { name: "Event", definedType: "Interface" },
           }, 
           {
-            name: "createdAt",
-            type: { name: "DateTime", definedType: "Scalar" },
-            typeCondition: { name: "Event", definedType: "Interface" },
-          }, 
-          {
-            name: "message",
-            type: { name: "FormattedString", definedType: "Scalar" },
-            typeCondition: { name: "Event", definedType: "Interface" },
-          }, 
-          {
-            name: "attributeToApp",
-            type: { name: "Boolean", definedType: "Scalar" },
-            typeCondition: { name: "Event", definedType: "Interface" },
-          }, 
-          {
-            name: "attributeToUser",
-            type: { name: "Boolean", definedType: "Scalar" },
-            typeCondition: { name: "Event", definedType: "Interface" },
-          }, 
-          {
-            name: "criticalAlert",
-            type: { name: "Boolean", definedType: "Scalar" },
-            typeCondition: { name: "Event", definedType: "Interface" },
-          }, 
-          {
             name: "__typename",
             type: { name: "String", definedType: "Scalar" },
             typeCondition: { name: "CommentEvent", definedType: "Object" },
@@ -274,7 +241,7 @@ export const timelineFragmentSelections: GraphSelection[] = ([
               }
             ] as GraphSelection[])
           }
-        ] as GraphSelection[])
+        ] as GraphSelection[]).concat(eventPreviewInfoSelections).concat(eventAttributeFieldsSelections).concat(eventAlertSelections)
       }
     ] as GraphSelection[])
   }

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/index.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/index.ts
@@ -2,6 +2,12 @@
 
 export type { BasicFragmentFragmentData } from "./BasicFragment"
 export { basicFragmentSelections } from "./BasicFragment"
+export type { EventAlertFragmentData } from "./EventAlert"
+export { eventAlertSelections } from "./EventAlert"
+export type { EventAttributeFieldsFragmentData } from "./EventAttributeFields"
+export { eventAttributeFieldsSelections } from "./EventAttributeFields"
+export type { EventPreviewInfoFragmentData } from "./EventPreviewInfo"
+export { eventPreviewInfoSelections } from "./EventPreviewInfo"
 export type { NodeIdFragmentData } from "./NodeId"
 export { nodeIdSelections } from "./NodeId"
 export type { ProductNodeTitleFragmentData } from "./ProductNodeTitle"

--- a/Tests/Resources/TestOperations/TypeScript/TimelineFragment.graphql
+++ b/Tests/Resources/TestOperations/TypeScript/TimelineFragment.graphql
@@ -6,11 +6,9 @@ fragment TimelineFragment on EventConnection {
     cursor
     node {
       id
-      createdAt
-      message
-      attributeToApp
-      attributeToUser
-      criticalAlert
+      ...EventPreviewInfo
+      ...EventAttributeFields
+      ...EventAlert
       ... on CommentEvent {
         edited
         canEdit
@@ -28,4 +26,18 @@ fragment TimelineFragment on EventConnection {
       }
     }
   }
+}
+
+fragment EventPreviewInfo on Event {
+  createdAt
+  message
+}
+
+fragment EventAttributeFields on Event {
+  attributeToApp
+  attributeToUser
+}
+
+fragment EventAlert on Event {
+  criticalAlert
 }


### PR DESCRIPTION
This PR fixes the cyclic import issue with `TypeScript` fragments that have nested fragments and imports them from the `index` file by having fragments import them from their individual file location.

**Before & After**
<img src="https://user-images.githubusercontent.com/17170253/150695775-7ad75e63-e672-4717-b37c-46335d25784d.png" width="80%" height="80%" />
