### PR TITLE
Fix TS quotes & remove unknown enum

### DIFF
--- a/Sources/SyrupCore/Stencil Extensions/SyrupStencilExtension.swift
+++ b/Sources/SyrupCore/Stencil Extensions/SyrupStencilExtension.swift
@@ -45,6 +45,7 @@ final class SyrupStencilExtension: Extension {
 		registerFilter("lowercasedFirstLetter", filter: SyrupStencilExtension.lowercasedFirstLetter)
 		registerFilter("replace", filter: SyrupStencilExtension.replace)
 		registerFilter("replaceQuotes", filter: SyrupStencilExtension.replaceQuotes)
+		registerFilter("replaceTypeScriptQuotes", filter: SyrupStencilExtension.replaceTypeScriptQuotes)
 		registerFilter("capitalizeFirstLetter", filter: SyrupStencilExtension.capitalizeFirstLetter)
 		registerFilter("pascalCase", filter: SyrupStencilExtension.pascalCase)
 		registerFilter("encryptData", filter: SyrupStencilExtension.encryptData)
@@ -90,6 +91,11 @@ final class SyrupStencilExtension: Extension {
 	static func replaceQuotes(_ value: Any?) throws -> Any? {
 		guard let value = value as? String else { return nil }
 		return value.replacingOccurrences(of: "\"", with: "\\\\\\\"")
+	}
+	
+	static func replaceTypeScriptQuotes(_ value: Any?) throws -> Any? {
+		guard let value = value as? String else { return nil }
+		return value.replacingOccurrences(of: "\"", with: "\\\"")
 	}
 	
 	static func capitalizeFirstLetter(_ value: Any?) throws -> Any? {

--- a/Templates/TypeScript/EnumType.stencil
+++ b/Templates/TypeScript/EnumType.stencil
@@ -5,9 +5,4 @@ export enum {{ enumType.name }} {
   {% with enumValue.attributes as attributes %}{% include "Helpers/Attributes.stencil" %}{% endwith %}
   {{ enumValue.value|pascalCase }} = "{{ enumValue.value }}",
   {% endfor %}
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Templates/TypeScript/Operation.stencil
+++ b/Templates/TypeScript/Operation.stencil
@@ -24,7 +24,7 @@ export interface {{ name }} {
 const document: SyrupOperation<{{ name }}, {% if operation.variables.count > 0 %}{{ name }}.Variables{% else %}{}{% endif %}> = {
   id: "{{ queryString|encryptData }}",
   name: "{{ operation.name }}",
-  source: "{{ queryString|replace:"$","\$"|replaceQuotes }}",
+  source: "{{ queryString|replace:"$","\$"|replaceTypeScriptQuotes }}",
   operationType: '{{ operation|renderOperationTypeName|lowercase } }}',
   selections: {{ selections|renderTypeScriptSelections:null,2 }}
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/CollectionRuleColumn.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/CollectionRuleColumn.ts
@@ -51,9 +51,4 @@ export enum CollectionRuleColumn {
    * The `variant_title` attribute.
    */
   VariantTitle = "VARIANT_TITLE",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/CollectionRuleRelation.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/CollectionRuleRelation.ts
@@ -51,9 +51,4 @@ export enum CollectionRuleRelation {
    * The attribute starts with the condition.
    */
   StartsWith = "STARTS_WITH",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/CollectionSortOrder.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/CollectionSortOrder.ts
@@ -41,9 +41,4 @@ export enum CollectionSortOrder {
    * By price, in descending order (highest - lowest).
    */
   PriceDesc = "PRICE_DESC",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/CountryCode.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/CountryCode.ts
@@ -1211,9 +1211,4 @@ export enum CountryCode {
    * Zimbabwe.
    */
   Zw = "ZW",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/CurrencyCode.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/CurrencyCode.ts
@@ -768,9 +768,4 @@ export enum CurrencyCode {
    * Zambian Kwacha (ZMW).
    */
   Zmw = "ZMW",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/CustomerMarketingOptInLevel.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/CustomerMarketingOptInLevel.ts
@@ -18,9 +18,4 @@ export enum CustomerMarketingOptInLevel {
    * The customer receives marketing emails, but the original opt-in process is unknown.
    */
   Unknown = "UNKNOWN",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/DigitalWallet.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/DigitalWallet.ts
@@ -21,9 +21,4 @@ export enum DigitalWallet {
    * Shopify Pay.
    */
   ShopifyPay = "SHOPIFY_PAY",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/FulfillmentDisplayStatus.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/FulfillmentDisplayStatus.ts
@@ -76,9 +76,4 @@ export enum FulfillmentDisplayStatus {
    * Displayed as **Submitted**.
    */
   Submitted = "SUBMITTED",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/FulfillmentEventStatus.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/FulfillmentEventStatus.ts
@@ -46,9 +46,4 @@ export enum FulfillmentEventStatus {
    * The fulfillment request failed.
    */
   Failure = "FAILURE",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/MetafieldValueType.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/MetafieldValueType.ts
@@ -16,9 +16,4 @@ export enum MetafieldValueType {
    * A JSON string.
    */
   JsonString = "JSON_STRING",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/OrderDisplayFulfillmentStatus.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/OrderDisplayFulfillmentStatus.ts
@@ -36,9 +36,4 @@ export enum OrderDisplayFulfillmentStatus {
    * Displayed as **In progress**.
    */
   InProgress = "IN_PROGRESS",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/PrivateMetafieldValueType.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/PrivateMetafieldValueType.ts
@@ -16,9 +16,4 @@ export enum PrivateMetafieldValueType {
    * A private metafield value type.
    */
   JsonString = "JSON_STRING",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/ProductVariantInventoryManagement.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/ProductVariantInventoryManagement.ts
@@ -16,9 +16,4 @@ export enum ProductVariantInventoryManagement {
    * A third-party fulfillment service tracks this product variant's inventory.
    */
   FulfillmentService = "FULFILLMENT_SERVICE",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/ProductVariantInventoryPolicy.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/ProductVariantInventoryPolicy.ts
@@ -11,9 +11,4 @@ export enum ProductVariantInventoryPolicy {
    * Continue selling a product variant when it is out of stock.
    */
   Continue = "CONTINUE",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/TaxExemption.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/TaxExemption.ts
@@ -101,9 +101,4 @@ export enum TaxExemption {
    * This customer is exempt from specific taxes for holding a valid FARMER_EXEMPTION in Saskatchewan.
    */
   CaSkFarmerExemption = "CA_SK_FARMER_EXEMPTION",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Enums/WeightUnit.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Enums/WeightUnit.ts
@@ -21,9 +21,4 @@ export enum WeightUnit {
    * Imperial system unit of mass.
    */
   Ounces = "OUNCES",
-
-  /**
-   * Unknown Syrup enum.
-   */
-  UnknownSyrupEnum = "UNKNOWN_SYRUP_ENUM"
 }

--- a/Tests/Resources/ExpectedTypeScriptCode/Queries/TestQuery0Query.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Queries/TestQuery0Query.ts
@@ -26,7 +26,7 @@ export interface TestQuery0QueryData {
 const document: SyrupOperation<TestQuery0QueryData, {}> = {
   id: "ed2f857cf0d2032aee79d91c5b4aa7165b90ee68eb89cad6438cf4be8d14eddc",
   name: "TestQuery0",
-  source: "query TestQuery0 { __typename nodes(ids: [\\\"gid://shopify/Customer/350635977\\\"]) { __typename id } }",
+  source: "query TestQuery0 { __typename nodes(ids: [\"gid://shopify/Customer/350635977\"]) { __typename id } }",
   operationType: 'query',
   selections: ([
     {

--- a/Tests/Resources/ExpectedTypeScriptCode/Queries/TestQuery3Query.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Queries/TestQuery3Query.ts
@@ -49,7 +49,7 @@ export interface TestQuery3QueryData {
 const document: SyrupOperation<TestQuery3QueryData, {}> = {
   id: "08177dad068a9da658aabc64345bdbcbf3efbc3db71a39256411bd3fd1687958",
   name: "TestQuery3",
-  source: "query TestQuery3 { __typename customer(id: \\\"\\\") { __typename addresses { __typename country } defaultAddress { __typename city longitude latitude } } }",
+  source: "query TestQuery3 { __typename customer(id: \"\") { __typename addresses { __typename country } defaultAddress { __typename city longitude latitude } } }",
   operationType: 'query',
   selections: ([
     {

--- a/Tests/Swift/TestResources/Shopify-TypeScript.yml
+++ b/Tests/Swift/TestResources/Shopify-TypeScript.yml
@@ -1,4 +1,4 @@
-location: https://app.shopify.com/services/graphql/introspection/admin?api_client_api_key=55c57a22d1f71e7aefa627803d712d69
+location: Tests/Swift/TestResources/Shopify-Schema.json
 customScalars:
 - graphType: Money
   nativeType: number


### PR DESCRIPTION
Resolves https://github.com/Shopify/syrup/issues/61

Removes `UNKNOWN_SYRUP_ENUM` from all enums. Not necessary since we are inferring types. Also fixes single `TypeScript` quotes.