### PR TITLE
TypeScript: Add support for GraphQL subscriptions

### DIFF
--- a/Sources/SyrupCore/Generator/Generator.swift
+++ b/Sources/SyrupCore/Generator/Generator.swift
@@ -417,6 +417,14 @@ public final class Generator {
 		concurrentPerform {
 			let renderer = TypeScriptRenderer(config: self.config)
 			
+			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.subscriptions }, fileType: .subscription, renderer: { (ir) -> [String] in
+				try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.subscriptions)
+			})
+		}
+		
+		concurrentPerform {
+			let renderer = TypeScriptRenderer(config: self.config)
+			
 			return try self.render(intermediateRepresentation: intermediateRepresentation, namesClosure: { $0.operations.mutations }, fileType: .mutation, renderer: { (ir) -> [String] in
 				try renderer.renderOperations(intermediateRepresentation: ir, selectionSets: selectionSets, operations: ir.operations.mutations)
 			})

--- a/Tests/Resources/ExpectedTypeScriptCode/Subscriptions/Subscription1Subscription.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Subscriptions/Subscription1Subscription.ts
@@ -1,0 +1,26 @@
+// Syrup auto-generated file
+
+import { ID, GraphSelection, SyrupOperation, copyWithTypeCondition } from "../GraphApi"
+
+export namespace Subscription1SubscriptionData {
+}
+
+export interface Subscription1SubscriptionData {
+
+  presenceChanged: boolean;
+}
+
+const document: SyrupOperation<Subscription1SubscriptionData, {}> = {
+  id: "60ffe5fded111be9f9d2f92c0d4dc51bdd6395527a7b1855adebfa0f5aeff5c9",
+  name: "Subscription1",
+  source: "subscription Subscription1 { presenceChanged }",
+  operationType: 'subscription',
+  selections: ([
+    {
+      name: "presenceChanged",
+      type: { name: "Boolean", definedType: "Scalar" },
+      typeCondition: { name: "Subscription", definedType: "Object" },
+    }
+  ] as GraphSelection[])
+}
+export default document

--- a/Tests/Resources/TestOperations/TypeScript/Subscriptions.graphql
+++ b/Tests/Resources/TestOperations/TypeScript/Subscriptions.graphql
@@ -1,0 +1,3 @@
+subscription Subscription1 {
+	presenceChanged
+}


### PR DESCRIPTION
### What does this change?

1) Updates the TypeScript generator to also generate subscription operations
2) Added a subscription to the TypeScript tests, verify CI is ✅ with the new operation