### PR TITLE
Fix base fields in union fragments & removed base field prefix

### DIFF
--- a/Templates/TypeScript/Helpers/UnionTypeBuilder.stencil
+++ b/Templates/TypeScript/Helpers/UnionTypeBuilder.stencil
@@ -12,7 +12,7 @@
   export interface {{ name }}_BaseFields_{% if fragmentSpreads.count > 0 %} extends {% for fragment in fragmentSpreads %}{{ fragment.name }}FragmentData._BaseFields_{% if not forloop.last %}, {% endif %}{% endfor %}{% endif %} {
 {% for field in commonFields %}
 {% with field.attributes as attributes %}{% with "  " as spacing %}{% include "Helpers/Attributes.stencil" %}{% endwith %}{% endwith %}
-    {{ field|renderPropertyDeclaration:name,"_BaseFields_" }};
+    {{ field|renderPropertyDeclaration:name }};
 {% endfor %}
   }
 {% endmacro %}{% block content %}{% endblock %}

--- a/Templates/TypeScript/UnionFragment.stencil
+++ b/Templates/TypeScript/UnionFragment.stencil
@@ -5,7 +5,7 @@ export namespace {{ name }}FragmentData {
 {% call renderUnionFields "" typeName commonFields collectedFields groupedFragmentSpreads concreteTypeNames fragmentSpreads parentFragment %}
 }
 
-export type {{ name }}FragmentData = {% for fragment in fragmentUnionTypes %}{{ fragment.fragmentName }}FragmentData.{{ fragment.fieldName }} | {% endfor %}{% for fragment in fragmentObjectTypes %}{{ fragment }}FragmentData | {% endfor %}{% for concreteTypeName in concreteTypeNames %}{{ name }}FragmentData.{{ concreteTypeName }} | {% endfor %}{{ name }}FragmentData.Other
+export type {{ name }}FragmentData = {{ name }}FragmentData._BaseFields_ & ({% for fragment in fragmentUnionTypes %}{{ fragment.fragmentName }}FragmentData.{{ fragment.fieldName }} | {% endfor %}{% for fragment in fragmentObjectTypes %}{{ fragment }}FragmentData | {% endfor %}{% for concreteTypeName in concreteTypeNames %}{{ name }}FragmentData.{{ concreteTypeName }} | {% endfor %}{{ name }}FragmentData.Other)
 
 export const {{ name|lowercasedFirstLetter }}Selections: GraphSelection[] = {{ selections|renderTypeScriptSelections:null,0 }}
 

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventAlert.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventAlert.ts
@@ -16,7 +16,7 @@ export namespace EventAlertFragmentData {
   }
 }
 
-export type EventAlertFragmentData = EventAlertFragmentData.Other
+export type EventAlertFragmentData = EventAlertFragmentData._BaseFields_ & (EventAlertFragmentData.Other)
 
 export const eventAlertSelections: GraphSelection[] = ([
   {

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventAttributeFields.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventAttributeFields.ts
@@ -21,7 +21,7 @@ export namespace EventAttributeFieldsFragmentData {
   }
 }
 
-export type EventAttributeFieldsFragmentData = EventAttributeFieldsFragmentData.Other
+export type EventAttributeFieldsFragmentData = EventAttributeFieldsFragmentData._BaseFields_ & (EventAttributeFieldsFragmentData.Other)
 
 export const eventAttributeFieldsSelections: GraphSelection[] = ([
   {

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventPreviewInfo.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/EventPreviewInfo.ts
@@ -21,7 +21,7 @@ export namespace EventPreviewInfoFragmentData {
   }
 }
 
-export type EventPreviewInfoFragmentData = EventPreviewInfoFragmentData.Other
+export type EventPreviewInfoFragmentData = EventPreviewInfoFragmentData._BaseFields_ & (EventPreviewInfoFragmentData.Other)
 
 export const eventPreviewInfoSelections: GraphSelection[] = ([
   {

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/NodeId.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/NodeId.ts
@@ -16,7 +16,7 @@ export namespace NodeIdFragmentData {
   }
 }
 
-export type NodeIdFragmentData = NodeIdFragmentData.Other
+export type NodeIdFragmentData = NodeIdFragmentData._BaseFields_ & (NodeIdFragmentData.Other)
 
 export const nodeIdSelections: GraphSelection[] = ([
   {

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/NodeIdTwo.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/NodeIdTwo.ts
@@ -16,7 +16,7 @@ export namespace NodeIdTwoFragmentData {
   }
 }
 
-export type NodeIdTwoFragmentData = NodeIdTwoFragmentData.Other
+export type NodeIdTwoFragmentData = NodeIdTwoFragmentData._BaseFields_ & (NodeIdTwoFragmentData.Other)
 
 export const nodeIdTwoSelections: GraphSelection[] = ([
   {

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/TimelineBasicEventFragment.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/TimelineBasicEventFragment.ts
@@ -23,7 +23,7 @@ export namespace TimelineBasicEventFragmentFragmentData {
   }
 }
 
-export type TimelineBasicEventFragmentFragmentData = TimelineBasicEventFragmentFragmentData.BasicEvent | TimelineBasicEventFragmentFragmentData.Other
+export type TimelineBasicEventFragmentFragmentData = TimelineBasicEventFragmentFragmentData._BaseFields_ & (TimelineBasicEventFragmentFragmentData.BasicEvent | TimelineBasicEventFragmentFragmentData.Other)
 
 export const timelineBasicEventFragmentSelections: GraphSelection[] = ([
   {

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/TimelineCommentEventFragment.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/TimelineCommentEventFragment.ts
@@ -19,7 +19,7 @@ export namespace TimelineCommentEventFragmentFragmentData {
   }
 }
 
-export type TimelineCommentEventFragmentFragmentData = TimelineCommentEventFragmentFragmentData.CommentEvent | TimelineCommentEventFragmentFragmentData.Other
+export type TimelineCommentEventFragmentFragmentData = TimelineCommentEventFragmentFragmentData._BaseFields_ & (TimelineCommentEventFragmentFragmentData.CommentEvent | TimelineCommentEventFragmentFragmentData.Other)
 
 export const timelineCommentEventFragmentSelections: GraphSelection[] = ([
   {

--- a/Tests/Resources/ExpectedTypeScriptCode/Fragments/TimelineEventFragment.ts
+++ b/Tests/Resources/ExpectedTypeScriptCode/Fragments/TimelineEventFragment.ts
@@ -97,7 +97,7 @@ export namespace TimelineEventFragmentFragmentData {
   }
 }
 
-export type TimelineEventFragmentFragmentData = TimelineEventFragmentFragmentData.CommentEvent | TimelineEventFragmentFragmentData.Other
+export type TimelineEventFragmentFragmentData = TimelineEventFragmentFragmentData._BaseFields_ & (TimelineEventFragmentFragmentData.CommentEvent | TimelineEventFragmentFragmentData.Other)
 
 export const timelineEventFragmentSelections: GraphSelection[] = ([
   {


### PR DESCRIPTION
Fixes base fields bug in union fragments and also removes the `BaseFields` prefix from inline union fields.