### PR TITLE
Bump swift-tools-support-core for Xcode 14/14.1 compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -47,12 +47,21 @@
         }
       },
       {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
+          "version": "1.1.1"
+        }
+      },
+      {
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
-          "version": "0.2.3"
+          "revision": "4f07be3dc201f6e2ee85b6942d0c220a16926811",
+          "version": "0.2.7"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
 		),
 		.package(
 			url: "https://github.com/apple/swift-tools-support-core.git",
-			.exact("0.2.3")
+			.exact("0.2.7")
 		),
 		.package(
 			url: "https://github.com/Shopify/SwiftGraphQLParser",


### PR DESCRIPTION
Bumps `swift-tools-support-core` to the [latest 2.x release](https://github.com/apple/swift-tools-support-core/releases/tag/0.2.7) which addresses building on Xcode 14.1. 

Tophat instructions:
1. With Xcode 14.0 toolchain `make` builds Syrup successfully
2. With Xcode 14.1 toolchain `make` builds Syrup successfully