### PR TITLE
Moving away from stencil fork

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -30,11 +30,11 @@
       },
       {
         "package": "Stencil",
-        "repositoryURL": "https://github.com/jaredh/Stencil",
+        "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
-          "branch": "master",
-          "revision": "cd3c6293a824882daa96f24c6e6c46dc633ecab4",
-          "version": null
+          "branch": null,
+          "revision": "4f222ac85d673f35df29962fc4c36ccfdaf9da5b",
+          "version": "0.15.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
 	],
 	dependencies: [
 		.package(
-			url: "https://github.com/jaredh/Stencil",
-			.branch("master")
+			url: "https://github.com/stencilproject/Stencil.git", 
+			from: "0.15.1"
 		),
 		.package(
 			url: "https://github.com/JohnSundell/files",
@@ -28,7 +28,7 @@ let package = Package(
 		),
 		.package(
 			url: "https://github.com/jpsim/Yams.git",
-			from: "4.0.6"
+			from: "5.0.6"
 		),
 		.package(
 			url: "https://github.com/apple/swift-tools-support-core.git",
@@ -38,10 +38,10 @@ let package = Package(
 			url: "https://github.com/Shopify/SwiftGraphQLParser",
 			from: "0.1.8"
 		),
-        .package(
-            url: "https://github.com/apple/swift-crypto.git",
-            .exact("1.1.6")
-        )
+		.package(
+				url: "https://github.com/apple/swift-crypto.git",
+				.exact("1.1.6")
+		)
 	],
 	targets: [
 		.target(

--- a/Sources/SyrupCore/Generator/Renderer.swift
+++ b/Sources/SyrupCore/Generator/Renderer.swift
@@ -61,7 +61,7 @@ open class Renderer {
 			print("Skipping missing template \(templateName)")
 			return ""
 		} catch let error as TemplateSyntaxError {
-			print("Syntax error in template \(template): \(error)")
+			print("Syntax error in template `\(template)`: \(error)")
 			throw error
 		} catch let error {
 			throw error

--- a/Templates/TypeScript/Operation.stencil
+++ b/Templates/TypeScript/Operation.stencil
@@ -25,7 +25,7 @@ const document: SyrupOperation<{{ name }}, {% if operation.variables.count > 0 %
   id: "{{ queryString|encryptData }}",
   name: "{{ operation.name }}",
   source: "{{ queryString|replace:"$","\$"|replaceTypeScriptQuotes }}",
-  operationType: '{{ operation|renderOperationTypeName|lowercase } }}',
+  operationType: '{{ operation|renderOperationTypeName|lowercase }}',
   selections: {{ selections|renderTypeScriptSelections:2 }}
 }
 export default document


### PR DESCRIPTION
Stencil is pointing to an unstable fork, likely to deal with an old xcode upgrade. 

This moves it back to the main release.

:tophat:

`https://github.com/Shopify/Syrup.git@jlock/update-stencil`

To tophat this change you can update your `Mintfile` line to point to this branch and run `dev ios graphql`. There is one error on notifications but I confirmed this was existing previous to this change.

